### PR TITLE
Add minimal GIA Adapter API with FastAPI and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+.venv/
+*.zip
+*.pyc
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run -p 8000:8000 gia-adapter
 POST `/generate`
 ```json
 {
-  "root": "HPSD_HealthVectorPort",
+  "root": "ExamplePort",
   "old_header": "<OLD HEADER>",
   "new_header": "<NEW HEADER>",
   "backend": "openai",

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# GIA-poc
+# GIA Adapter API
+
+## What this service does
+Generates versioned adapters for C structs by calling an LLM. Given two preprocessed headers and a root struct name, it returns four files implementing conversion logic between versions.
+
+## How to run
+### Local
+```bash
+pip install -r requirements.txt
+uvicorn app:app --reload
+```
+Service listens on `http://localhost:8000`.
+
+### Docker
+```bash
+docker build -t gia-adapter .
+docker run -p 8000:8000 gia-adapter
+```
+
+## API
+POST `/generate`
+```json
+{
+  "root": "HPSD_HealthVectorPort",
+  "old_header": "<OLD HEADER>",
+  "new_header": "<NEW HEADER>",
+  "backend": "openai",
+  "model": "gpt-5",
+  "temperature": 0.0,
+  "return_zip": true
+}
+```
+Response contains the generated files and optional base64 ZIP.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/generate \
+  -H 'Content-Type: application/json' \
+  -d '{"root":"R","old_header":"H1","new_header":"H2"}'
+```
+
+## Backend config
+* **OpenAI** (default) — requires `OPENAI_API_KEY` env var.
+* **Offline** — set `backend` to `offline` and provide `OFFLINE_LLM_ENDPOINT` env var.
+
+## Prompt contract
+System and user prompts are defined in `prompt_text.py`. The LLM must return exactly four files or a single C comment block on error.
+
+## Validation & error codes
+* `400` – missing or oversized inputs.
+* `409` – no common root.
+* `422` – malformed LLM output.
+* `424` – backend failure (missing key, timeout).
+* `500` – unexpected.
+
+## Running tests
+```bash
+pytest -q
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI, HTTPException
+
+from llm_backends import get_backend, LLMError
+from models import GenerateRequest, GenerateResponse
+from parser_validator import parse_llm_files, zip_base64
+from prompt_text import SYSTEM_PROMPT, build_user_prompt
+
+app = FastAPI()
+
+MAX_HEADER_LEN = 100_000
+
+
+@app.post("/generate", response_model=GenerateResponse)
+def generate(req: GenerateRequest) -> GenerateResponse:
+    if not req.root or not req.old_header or not req.new_header:
+        raise HTTPException(status_code=400, detail="missing input")
+    if len(req.old_header) > MAX_HEADER_LEN or len(req.new_header) > MAX_HEADER_LEN:
+        raise HTTPException(status_code=400, detail="input too large")
+
+    try:
+        backend = get_backend(req.backend, req.model, req.temperature)
+    except LLMError as e:
+        raise HTTPException(status_code=424, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    system_prompt = SYSTEM_PROMPT
+    user_prompt = build_user_prompt(req.root, req.old_header, req.new_header)
+    try:
+        text = backend.generate(system_prompt, user_prompt)
+    except Exception as e:  # backend failure
+        raise HTTPException(status_code=424, detail=str(e))
+
+    try:
+        files = parse_llm_files(text)
+    except HTTPException as e:
+        raise e
+    except Exception as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    zip_str = zip_base64(files) if req.return_zip else None
+    return GenerateResponse(root=req.root, files=files, zip_base64=zip_str)

--- a/llm_backends.py
+++ b/llm_backends.py
@@ -1,0 +1,71 @@
+import os
+from abc import ABC, abstractmethod
+from typing import Optional
+import requests
+from openai import OpenAI
+
+
+class LLMError(Exception):
+    pass
+
+
+class LLMClient(ABC):
+    def __init__(self, model: str = "gpt-5", temperature: float = 0.0):
+        self.model = model
+        self.temperature = temperature
+
+    @abstractmethod
+    def generate(self, system: str, user: str) -> str:
+        raise NotImplementedError
+
+
+class CloudLLM(LLMClient):
+    def __init__(self, model: str = "gpt-5", temperature: float = 0.0):
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise LLMError("missing OPENAI_API_KEY")
+        super().__init__(model, temperature)
+        self.client = OpenAI(api_key=api_key)
+
+    def generate(self, system: str, user: str) -> str:
+        resp = self.client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "system", "content": system}, {"role": "user", "content": user}],
+            temperature=self.temperature,
+        )
+        return resp.choices[0].message.content
+
+
+class OfflineLLM(LLMClient):
+    def __init__(self, model: str = "gpt-5", temperature: float = 0.0):
+        endpoint = os.getenv("OFFLINE_LLM_ENDPOINT")
+        if not endpoint:
+            raise LLMError("missing OFFLINE_LLM_ENDPOINT")
+        super().__init__(model, temperature)
+        self.endpoint = endpoint
+
+    def generate(self, system: str, user: str) -> str:
+        payload = {
+            "model": self.model,
+            "temperature": self.temperature,
+            "prompt": f"{system}\n{user}",
+        }
+        r = requests.post(self.endpoint, json=payload, timeout=60)
+        r.raise_for_status()
+        data = r.json()
+        if isinstance(data, dict):
+            return (
+                data.get("content")
+                or data.get("text")
+                or data.get("choices", [{}])[0].get("text", "")
+            )
+        return str(data)
+
+
+def get_backend(name: str, model: str, temperature: float) -> LLMClient:
+    name = name or "openai"
+    if name == "openai":
+        return CloudLLM(model=model, temperature=temperature)
+    if name == "offline":
+        return OfflineLLM(model=model, temperature=temperature)
+    raise ValueError("unknown backend")

--- a/models.py
+++ b/models.py
@@ -1,0 +1,24 @@
+from typing import List, Optional
+from pydantic import BaseModel
+
+
+class GenerateRequest(BaseModel):
+    root: str
+    old_header: str
+    new_header: str
+    backend: str = "openai"
+    model: str = "gpt-5"
+    temperature: float = 0.0
+    return_zip: bool = True
+
+
+class FileOut(BaseModel):
+    name: str
+    language: str
+    content: str
+
+
+class GenerateResponse(BaseModel):
+    root: str
+    files: List[FileOut]
+    zip_base64: Optional[str]

--- a/parser_validator.py
+++ b/parser_validator.py
@@ -15,7 +15,7 @@ def parse_llm_files(text: str) -> List[FileOut]:
         raise HTTPException(status_code=409, detail=text.strip())
     text = text.strip()
     matches = list(FILE_RE.finditer(text))
-    if len(matches) != 4 or "".join(m.group(0) for m in matches).strip() != text:
+    if len(matches) != 4 or FILE_RE.sub("", text).strip():
         raise HTTPException(status_code=422, detail="expected four file blocks")
     files = []
     has_versioned = has_conv_h = has_conv_cpp = has_converters = False

--- a/parser_validator.py
+++ b/parser_validator.py
@@ -1,0 +1,43 @@
+import base64
+import io
+import re
+import zipfile
+from typing import List
+from fastapi import HTTPException
+
+from models import FileOut
+
+FILE_RE = re.compile(r"// FILE: ([^\n]+)\n```(c|cpp)\n(.*?)\n```", re.DOTALL)
+
+
+def parse_llm_files(text: str) -> List[FileOut]:
+    if re.fullmatch(r"\s*/\*.*?\*/\s*", text, re.DOTALL):
+        raise HTTPException(status_code=409, detail=text.strip())
+    text = text.strip()
+    matches = list(FILE_RE.finditer(text))
+    if len(matches) != 4 or "".join(m.group(0) for m in matches).strip() != text:
+        raise HTTPException(status_code=422, detail="expected four file blocks")
+    files = []
+    has_versioned = has_conv_h = has_conv_cpp = has_converters = False
+    for m in matches:
+        name, lang, body = m.group(1).strip(), m.group(2), m.group(3)
+        files.append(FileOut(name=name, language=lang, content=body))
+        if name.endswith("_versioned.h"):
+            has_versioned = True
+        elif name.startswith("Converter_") and name.endswith(".h"):
+            has_conv_h = True
+        elif name.startswith("Converter_") and name.endswith(".cpp"):
+            has_conv_cpp = True
+        elif name == "converters.cpp":
+            has_converters = True
+    if not (has_versioned and has_conv_h and has_conv_cpp and has_converters):
+        raise HTTPException(status_code=422, detail="missing expected files")
+    return files
+
+
+def zip_base64(files: List[FileOut]) -> str:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for f in files:
+            zf.writestr(f.name, f.content)
+    return base64.b64encode(buf.getvalue()).decode("utf-8")

--- a/prompt_text.py
+++ b/prompt_text.py
@@ -1,0 +1,70 @@
+SYSTEM_PROMPT = """You are a deterministic code generator. The repository is empty. Given two preprocessed C headers (OLD and NEW) and a Root struct name, output exactly four files that preserve version history and enable conversion via a generic superset. No prose. No external tools.
+Root selection (resilient):
+
+If typedef struct … <Root>; exists in BOTH headers → use it.
+
+Else auto-discover the best common struct: appears in both headers, most similar name to <Root> (case/underscore insensitive); prefer a struct that embeds multiple sub-structs and a version/integer field.
+
+If no common struct exists in both headers, return one C comment block only: /* error: no common root; OLD-only: {...}; NEW-only: {...} */
+Versioning:
+
+For each struct reachable from Root: if unchanged → emit one definition; if changed → emit Name_V_OLD, Name_V_NEW, Name_V_Gen (superset = union of fields).
+
+_V_Gen order: OLD-only fields in OLD order, then NEW-only fields in NEW order (skip duplicates).
+
+Renames: if OLD field not in NEW but a very similar name (normalized similarity ≥ 0.90) exists → treat as rename; include both names in _V_Gen.
+
+Type conflicts: prefer wider/safer scalar; if ambiguous, keep both with suffixes __old/__new.
+
+Enums: if members differ, NEW is canonical; implement explicit mapping in converters.
+Defaults when converting: bool→false; ints/floats→0; pointers→NULL; enums→first enumerator.
+Converters (root-level only) — declare & implement 4 functions:
+
+int convert_<Root>_V_Gen_to_V_OLD(const <Root>_V_Gen*, <Root>_V_OLD*);
+int convert_<Root>_V_Gen_to_V_NEW(const <Root>_V_Gen*, <Root>_V_NEW*);
+int convert_<Root>_V_OLD_to_V_Gen(const <Root>_V_OLD*, <Root>_V_Gen*);
+int convert_<Root>_V_NEW_to_V_Gen(const <Root>_V_NEW*, <Root>_V_Gen*);
+
+
+Return -1 on NULLs; else 0. Copy unchanged sub-structs verbatim. For changed sub-structs: OLD→GEN and NEW→GEN copy their fields and mirror rename pairs into both names in _V_Gen; GEN→OLD/NEW prefer the target’s canonical name, falling back to the rename partner; default if absent. No heap; zero-init targets where useful.
+Headers & style: C99 types (<stdint.h>, <stdbool.h>), <string.h> as needed; guard names <ROOT_UPPER>_VERSIONED_H and CONVERTER_<ROOT_UPPER>_H; concise history comment in <Root>_versioned.h.
+Output protocol (strict): Return exactly four code blocks, each preceded by a filename marker:
+
+// FILE: <Root>_versioned.h
+```c
+...code...
+
+
+// FILE: Converter_<Root>.h
+
+...code...
+
+
+// FILE: Converter_<Root>.cpp
+
+...code...
+
+
+// FILE: converters.cpp
+
+...code...
+
+
+If you must error, return one C comment block only and nothing else."""
+
+
+def build_user_prompt(root: str, old_header: str, new_header: str) -> str:
+    return f"""Task: Generate a generic adapter. The repository is empty; create all four files.
+
+Root struct name: {root}
+
+OLD header:
+------------------ BEGIN OLD ------------------
+{old_header}
+------------------- END OLD -------------------
+
+NEW header:
+------------------ BEGIN NEW ------------------
+{new_header}
+------------------- END NEW -------------------
+"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.*
+uvicorn[standard]==0.30.*
+pydantic==2.*
+requests==2.*
+openai>=1.0.0
+pytest==8.*

--- a/tests/fixtures/new_header.h
+++ b/tests/fixtures/new_header.h
@@ -7,4 +7,4 @@ typedef struct {
     SampleInner inner;
     int flag;
     bool active;
-} HPSD_HealthVectorPort;
+} ExamplePort;

--- a/tests/fixtures/new_header.h
+++ b/tests/fixtures/new_header.h
@@ -1,0 +1,10 @@
+typedef struct {
+    int value;
+    int total;
+} SampleInner;
+
+typedef struct {
+    SampleInner inner;
+    int flag;
+    bool active;
+} HPSD_HealthVectorPort;

--- a/tests/fixtures/old_header.h
+++ b/tests/fixtures/old_header.h
@@ -1,0 +1,9 @@
+typedef struct {
+    int value;
+    int count;
+} SampleInner;
+
+typedef struct {
+    SampleInner inner;
+    int flag;
+} HPSD_HealthVectorPort;

--- a/tests/fixtures/old_header.h
+++ b/tests/fixtures/old_header.h
@@ -6,4 +6,4 @@ typedef struct {
 typedef struct {
     SampleInner inner;
     int flag;
-} HPSD_HealthVectorPort;
+} ExamplePort;

--- a/tests/test_generate_ok.py
+++ b/tests/test_generate_ok.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app import app
+from llm_backends import CloudLLM
+
+
+def mock_generate(self, system: str, user: str) -> str:
+    return (
+        "// FILE: HPSD_HealthVectorPort_versioned.h\n```c\nv1\n```\n"
+        "// FILE: Converter_HPSD_HealthVectorPort.h\n```c\nv2\n```\n"
+        "// FILE: Converter_HPSD_HealthVectorPort.cpp\n```cpp\nv3\n```\n"
+        "// FILE: converters.cpp\n```cpp\nv4\n```"
+    )
+
+
+def test_generate_ok(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setattr(CloudLLM, "generate", mock_generate)
+    client = TestClient(app)
+    fixtures = Path(__file__).parent / "fixtures"
+    old_header = (fixtures / "old_header.h").read_text()
+    new_header = (fixtures / "new_header.h").read_text()
+    payload = {
+        "root": "HPSD_HealthVectorPort",
+        "old_header": old_header,
+        "new_header": new_header,
+        "backend": "openai",
+        "return_zip": True,
+    }
+    resp = client.post("/generate", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["root"] == "HPSD_HealthVectorPort"
+    names = {f["name"] for f in data["files"]}
+    assert names == {
+        "HPSD_HealthVectorPort_versioned.h",
+        "Converter_HPSD_HealthVectorPort.h",
+        "Converter_HPSD_HealthVectorPort.cpp",
+        "converters.cpp",
+    }
+    for f in data["files"]:
+        assert f["content"]
+    assert data["zip_base64"]

--- a/tests/test_generate_ok.py
+++ b/tests/test_generate_ok.py
@@ -8,9 +8,9 @@ from llm_backends import CloudLLM
 
 def mock_generate(self, system: str, user: str) -> str:
     return (
-        "// FILE: HPSD_HealthVectorPort_versioned.h\n```c\nv1\n```\n"
-        "// FILE: Converter_HPSD_HealthVectorPort.h\n```c\nv2\n```\n"
-        "// FILE: Converter_HPSD_HealthVectorPort.cpp\n```cpp\nv3\n```\n"
+        "// FILE: ExamplePort_versioned.h\n```c\nv1\n```\n"
+        "// FILE: Converter_ExamplePort.h\n```c\nv2\n```\n"
+        "// FILE: Converter_ExamplePort.cpp\n```cpp\nv3\n```\n"
         "// FILE: converters.cpp\n```cpp\nv4\n```"
     )
 
@@ -23,7 +23,7 @@ def test_generate_ok(monkeypatch):
     old_header = (fixtures / "old_header.h").read_text()
     new_header = (fixtures / "new_header.h").read_text()
     payload = {
-        "root": "HPSD_HealthVectorPort",
+        "root": "ExamplePort",
         "old_header": old_header,
         "new_header": new_header,
         "backend": "openai",
@@ -32,12 +32,12 @@ def test_generate_ok(monkeypatch):
     resp = client.post("/generate", json=payload)
     assert resp.status_code == 200
     data = resp.json()
-    assert data["root"] == "HPSD_HealthVectorPort"
+    assert data["root"] == "ExamplePort"
     names = {f["name"] for f in data["files"]}
     assert names == {
-        "HPSD_HealthVectorPort_versioned.h",
-        "Converter_HPSD_HealthVectorPort.h",
-        "Converter_HPSD_HealthVectorPort.cpp",
+        "ExamplePort_versioned.h",
+        "Converter_ExamplePort.h",
+        "Converter_ExamplePort.cpp",
         "converters.cpp",
     }
     for f in data["files"]:


### PR DESCRIPTION
## Summary
- implement FastAPI service to generate adapter files via LLM backends
- add OpenAI and offline LLM backend clients
- include parser, prompt texts, models, Docker setup, and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi'; packages could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c159586f70832d9197d32aa34fee63