### PR TITLE
Allow whitespace between file blocks in parser validation

### DIFF
--- a/parser_validator.py
+++ b/parser_validator.py
@@ -15,7 +15,7 @@ def parse_llm_files(text: str) -> List[FileOut]:
         raise HTTPException(status_code=409, detail=text.strip())
     text = text.strip()
     matches = list(FILE_RE.finditer(text))
-    if len(matches) != 4 or "".join(m.group(0) for m in matches).strip() != text:
+    if len(matches) != 4 or FILE_RE.sub("", text).strip():
         raise HTTPException(status_code=422, detail="expected four file blocks")
     files = []
     has_versioned = has_conv_h = has_conv_cpp = has_converters = False


### PR DESCRIPTION
## Summary
- relax parser block validation to allow blank lines between file blocks

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.115.*; 403 Forbidden when connecting to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c198cb0e34832d938d0037eb3b1e31