### PR TITLE
Add CLI helper for local generator execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,37 @@
 Generates versioned adapters for C structs by calling an LLM. Given two preprocessed headers and a root struct name, it returns four files implementing conversion logic between versions.
 
 ## How to run
-### Local
-```bash
-pip install -r requirements.txt
-uvicorn app:app --reload
-```
-Service listens on `http://localhost:8000`.
+
+### Local workflow
+1. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. **Provide LLM credentials**
+   The default backend talks to OpenAI. Export the API key in the shell that
+   starts Uvicorn so the process can discover it:
+   ```bash
+   # macOS/Linux
+   export OPENAI_API_KEY="sk-your-secret"
+
+   # Windows PowerShell (open a new terminal afterwards)
+   setx OPENAI_API_KEY "sk-your-secret"
+   ```
+   The repository never stores the key; rotate it immediately if you suspect
+   exposure.
+3. **Start the FastAPI server**
+   ```bash
+   uvicorn app:app --reload
+   ```
+   The API listens on `http://localhost:8000`.
+4. **Call the generator**
+   With the server running you can execute the cross-platform helper script.
+   The defaults use the bundled fixtures so the first run works out of the box:
+   ```bash
+   python scripts/run_generator.py
+   ```
+   Use `python scripts/run_generator.py --help` to inspect additional
+   parameters (custom headers, backend overrides, dumping JSON, etc.).
 
 ### Docker
 ```bash
@@ -32,7 +57,27 @@ POST `/generate`
 ```
 Response contains the generated files and optional base64 ZIP.
 
-Example:
+### Local invocation helper
+The repository ships with `scripts/run_generator.py`, a small CLI that
+assembles the payload and posts it to the running FastAPI instance.  Because
+our test-suite imports the same helper the automated checks exercise the exact
+request that the script emits.
+
+Quick start (uses the fixture headers and requests a ZIP bundle):
+```bash
+python scripts/run_generator.py
+```
+
+To target different headers or a different backend:
+```bash
+python scripts/run_generator.py \
+  --root MyStruct \
+  --old-header path/to/old.h \
+  --new-header path/to/new.h \
+  --backend offline
+```
+
+If you prefer manual requests you can still use `curl`:
 ```bash
 curl -X POST http://localhost:8000/generate \
   -H 'Content-Type: application/json' \

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,11 @@
+"""Helper utilities for local generator execution."""
+from __future__ import annotations
+
+__all__ = [
+    "DEFAULT_API_URL",
+    "build_payload",
+    "call_generator",
+    "format_response_summary",
+]
+
+from .run_generator import DEFAULT_API_URL, build_payload, call_generator, format_response_summary

--- a/scripts/run_generator.py
+++ b/scripts/run_generator.py
@@ -1,0 +1,166 @@
+"""CLI helper for calling the /generate endpoint locally.
+
+The module exposes reusable helpers that our test-suite imports so the
+happy-path test mirrors the behaviour of the command-line tool.  Keeping
+both code paths in sync guarantees that local invocations and automated
+checks operate on the exact same payload and response expectations.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+import requests
+
+DEFAULT_API_URL = "http://localhost:8000/generate"
+
+
+def build_payload(
+    *,
+    root: str,
+    old_header_path: Path | str,
+    new_header_path: Path | str,
+    backend: str = "openai",
+    return_zip: bool = True,
+    model: str | None = None,
+    temperature: float | None = None,
+) -> Dict[str, Any]:
+    """Create the JSON payload expected by the generator service.
+
+    Parameters mirror the API schema and allow tests as well as the CLI to
+    share the exact same request body.  Paths are resolved relative to the
+    current working directory so the command works on every platform.
+    """
+
+    old_header_text = Path(old_header_path).expanduser().resolve().read_text()
+    new_header_text = Path(new_header_path).expanduser().resolve().read_text()
+    payload: Dict[str, Any] = {
+        "root": root,
+        "old_header": old_header_text,
+        "new_header": new_header_text,
+        "backend": backend,
+        "return_zip": return_zip,
+    }
+    if model is not None:
+        payload["model"] = model
+    if temperature is not None:
+        payload["temperature"] = temperature
+    return payload
+
+
+def call_generator(url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Invoke the generator endpoint and return the parsed JSON body."""
+
+    response = requests.post(url, json=payload, timeout=120)
+    response.raise_for_status()
+    return response.json()
+
+
+def format_response_summary(data: Dict[str, Any]) -> Iterable[str]:
+    """Yield human-readable lines that describe the generator result."""
+
+    root = data.get("root", "<unknown>")
+    files = data.get("files", []) or []
+    yield f"Root: {root}"
+    if not files:
+        yield "No files returned"
+        return
+    yield "Files:"
+    for entry in files:
+        name = entry.get("name", "<unnamed>")
+        size = len(entry.get("content", ""))
+        yield f"  - {name} ({size} bytes of content)"
+    if data.get("zip_base64"):
+        yield "Zip archive: present"
+    else:
+        yield "Zip archive: not requested"
+
+
+def _warn_missing_openai_key(backend: str) -> None:
+    if backend == "openai" and not os.getenv("OPENAI_API_KEY"):
+        print(
+            "[warning] OPENAI_API_KEY is not set; the FastAPI server will reject",
+            "requests when the OpenAI backend is selected.",
+        )
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Call the local GIA generator")
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_API_URL,
+        help=f"Generator endpoint URL (default: {DEFAULT_API_URL})",
+    )
+    parser.add_argument(
+        "--root",
+        default="ExamplePort",
+        help="Root struct name to seed the adapter generation",
+    )
+    parser.add_argument(
+        "--old-header",
+        default=str(Path("tests/fixtures/old_header.h")),
+        help="Path to the legacy header file",
+    )
+    parser.add_argument(
+        "--new-header",
+        default=str(Path("tests/fixtures/new_header.h")),
+        help="Path to the updated header file",
+    )
+    parser.add_argument(
+        "--backend",
+        default="openai",
+        help="LLM backend identifier (default: openai)",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Optional model override passed to the backend",
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=None,
+        help="Optional sampling temperature passed to the backend",
+    )
+    parser.add_argument(
+        "--no-zip",
+        action="store_true",
+        help="Skip requesting the base64 zip payload in the response",
+    )
+    parser.add_argument(
+        "--dump-json",
+        type=Path,
+        default=None,
+        help="Optional file to write the raw JSON response to",
+    )
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    _warn_missing_openai_key(args.backend)
+
+    payload = build_payload(
+        root=args.root,
+        old_header_path=args.old_header,
+        new_header_path=args.new_header,
+        backend=args.backend,
+        return_zip=not args.no_zip,
+        model=args.model,
+        temperature=args.temperature,
+    )
+    data = call_generator(args.url, payload)
+
+    if args.dump_json:
+        args.dump_json.write_text(json.dumps(data, indent=2))
+        print(f"Wrote response to {args.dump_json}")
+
+    for line in format_response_summary(data):
+        print(line)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via CLI usage
+    raise SystemExit(main())

--- a/tests/test_generate_ok.py
+++ b/tests/test_generate_ok.py
@@ -1,10 +1,15 @@
-import pytest
 from pathlib import Path
 
 from fastapi.testclient import TestClient
 
 from app import app
 from llm_backends import CloudLLM
+from scripts.run_generator import (
+    DEFAULT_API_URL,
+    build_payload,
+    call_generator,
+    format_response_summary,
+)
 
 
 def mock_generate(self, system: str, user: str) -> str:
@@ -16,23 +21,7 @@ def mock_generate(self, system: str, user: str) -> str:
     )
 
 
-def test_generate_ok(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "test")
-    monkeypatch.setattr(CloudLLM, "generate", mock_generate)
-    client = TestClient(app)
-    fixtures = Path(__file__).parent / "fixtures"
-    old_header = (fixtures / "old_header.h").read_text()
-    new_header = (fixtures / "new_header.h").read_text()
-    payload = {
-        "root": "ExamplePort",
-        "old_header": old_header,
-        "new_header": new_header,
-        "backend": "openai",
-        "return_zip": True,
-    }
-    resp = client.post("/generate", json=payload)
-    assert resp.status_code == 200
-    data = resp.json()
+def assert_success_response(data):
     assert data["root"] == "ExamplePort"
     names = {f["name"] for f in data["files"]}
     assert names == {
@@ -44,4 +33,54 @@ def test_generate_ok(monkeypatch):
     for f in data["files"]:
         assert f["content"]
     assert data["zip_base64"]
+
+
+def test_generate_ok(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setattr(CloudLLM, "generate", mock_generate)
+    client = TestClient(app)
+    fixtures = Path(__file__).parent / "fixtures"
+    payload = build_payload(
+        root="ExamplePort",
+        old_header_path=fixtures / "old_header.h",
+        new_header_path=fixtures / "new_header.h",
+    )
+    resp = client.post("/generate", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert_success_response(data)
+
+
+def test_call_generator_matches_cli(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setattr(CloudLLM, "generate", mock_generate)
+    client = TestClient(app)
+    fixtures = Path(__file__).parent / "fixtures"
+    payload = build_payload(
+        root="ExamplePort",
+        old_header_path=fixtures / "old_header.h",
+        new_header_path=fixtures / "new_header.h",
+    )
+
+    def fake_post(url, json, timeout):
+        assert url == DEFAULT_API_URL
+        resp = client.post("/generate", json=json)
+
+        class _Wrapper:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def raise_for_status(self):
+                self._inner.raise_for_status()
+
+            def json(self):
+                return self._inner.json()
+
+        return _Wrapper(resp)
+
+    monkeypatch.setattr("scripts.run_generator.requests.post", fake_post)
+    data = call_generator(DEFAULT_API_URL, payload)
+    assert_success_response(data)
+    summary_lines = list(format_response_summary(data))
+    assert any("ExamplePort_versioned.h" in line for line in summary_lines)
 


### PR DESCRIPTION
## Summary
- add a reusable Python CLI for invoking the local /generate endpoint with shared helper functions
- expand the README with step-by-step setup instructions, including OpenAI key export guidance and the new script workflow
- update the happy-path tests to reuse the CLI helpers so automated checks mirror local execution

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d84016d6f4832dbdf291ac918d6bd4