### PR TITLE
Add local llama backend support and dedicated CLI scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,18 @@ Generates versioned adapters for C structs by calling an LLM. Given two preproce
    ```
    The API listens on `http://localhost:8000`.
 4. **Call the generator**
-   With the server running you can execute the cross-platform helper script.
-   The defaults use the bundled fixtures so the first run works out of the box:
+   With the server running you can execute one of the helper scripts depending
+   on the backend you want to exercise. Both reuse the same code paths as the
+   automated tests so the behaviour is identical:
    ```bash
-   python scripts/run_generator.py
+   # OpenAI backend
+   python scripts/run_generator_openai.py
+
+   # Local llama.cpp backend (see below for setup details)
+   python scripts/run_generator_local.py
    ```
-   Use `python scripts/run_generator.py --help` to inspect additional
-   parameters (custom headers, backend overrides, dumping JSON, etc.).
+   Use `--help` to inspect additional parameters (custom headers, temperature
+   overrides, dumping JSON, etc.).
 
 ### Docker
 ```bash
@@ -65,16 +70,15 @@ request that the script emits.
 
 Quick start (uses the fixture headers and requests a ZIP bundle):
 ```bash
-python scripts/run_generator.py
+python scripts/run_generator_openai.py
 ```
 
 To target different headers or a different backend:
 ```bash
-python scripts/run_generator.py \
+python scripts/run_generator_openai.py \
   --root MyStruct \
   --old-header path/to/old.h \
-  --new-header path/to/new.h \
-  --backend offline
+  --new-header path/to/new.h
 ```
 
 If you prefer manual requests you can still use `curl`:
@@ -87,6 +91,11 @@ curl -X POST http://localhost:8000/generate \
 ## Backend config
 * **OpenAI** (default) — requires `OPENAI_API_KEY` env var.
 * **Offline** — set `backend` to `offline` and provide `OFFLINE_LLM_ENDPOINT` env var.
+* **Local llama.cpp** — install `llama-cpp-python`, download a GGUF checkpoint and
+  point `LLAMA_MODEL_PATH` (or `--model`) at it. The convenience script
+  `scripts/run_generator_local.py` defaults to
+  `~/.llama/checkpoints/Llama-4-Scout-17B-16E-Instruct` and verifies the file
+  exists before issuing the request.
 
 ## Prompt contract
 System and user prompts are defined in `prompt_text.py`. The LLM must return exactly four files or a single C comment block on error.

--- a/llm_backends.py
+++ b/llm_backends.py
@@ -1,6 +1,8 @@
 import os
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Optional
+
 import requests
 from openai import OpenAI
 
@@ -10,7 +12,7 @@ class LLMError(Exception):
 
 
 class LLMClient(ABC):
-    def __init__(self, model: str = "gpt-5", temperature: float = 0.0):
+    def __init__(self, model: Optional[str] = None, temperature: float = 0.0):
         self.model = model
         self.temperature = temperature
 
@@ -62,10 +64,75 @@ class OfflineLLM(LLMClient):
         return str(data)
 
 
-def get_backend(name: str, model: str, temperature: float) -> LLMClient:
+class LocalLlamaLLM(LLMClient):
+    """LLM backend that runs llama.cpp locally on a downloaded checkpoint."""
+
+    def __init__(self, model: Optional[str] = None, temperature: float = 0.0):
+        super().__init__(model=model, temperature=temperature)
+        candidate = model
+        if not candidate or candidate == "gpt-5":
+            candidate = os.getenv("LLAMA_MODEL_PATH")
+        if not candidate:
+            raise LLMError("missing LLAMA_MODEL_PATH or model path override")
+        model_path = Path(candidate).expanduser()
+        if not model_path.exists():
+            raise LLMError(f"local model not found: {model_path}")
+        self.model_path = model_path
+        self.model = str(model_path)
+        self._client = None
+
+    def _ensure_client(self):
+        if self._client is not None:
+            return
+        try:
+            from llama_cpp import Llama  # type: ignore
+        except ImportError as exc:
+            raise LLMError(
+                "llama-cpp-python is not installed; install it to use the local backend"
+            ) from exc
+        try:
+            self._client = Llama(model_path=str(self.model_path))
+        except Exception as exc:  # pragma: no cover - surface informative error
+            raise LLMError(f"failed to initialise llama.cpp backend: {exc}") from exc
+
+    def generate(self, system: str, user: str) -> str:
+        self._ensure_client()
+        assert self._client is not None  # for type checkers
+        try:
+            response = self._client.create_chat_completion(
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                temperature=self.temperature,
+            )
+        except Exception as exc:  # pragma: no cover - runtime error surfaced to caller
+            raise LLMError(f"llama.cpp generation failed: {exc}") from exc
+
+        if not isinstance(response, dict):
+            raise LLMError("unexpected response from llama.cpp")
+        choices = response.get("choices") or []
+        if not choices:
+            raise LLMError("llama.cpp returned no choices")
+        message = choices[0].get("message", {}) or {}
+        content = message.get("content")
+        if isinstance(content, list):
+            content = "".join(
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            )
+        if not isinstance(content, str) or not content.strip():
+            raise LLMError("llama.cpp returned empty content")
+        return content
+
+
+def get_backend(name: str, model: Optional[str], temperature: float) -> LLMClient:
     name = name or "openai"
     if name == "openai":
-        return CloudLLM(model=model, temperature=temperature)
+        return CloudLLM(model=model or "gpt-5", temperature=temperature)
     if name == "offline":
-        return OfflineLLM(model=model, temperature=temperature)
+        return OfflineLLM(model=model or "gpt-5", temperature=temperature)
+    if name in {"local", "local-llama", "llama"}:
+        return LocalLlamaLLM(model=model, temperature=temperature)
     raise ValueError("unknown backend")

--- a/llm_backends.py
+++ b/llm_backends.py
@@ -109,6 +109,10 @@ class LocalLlamaLLM(LLMClient):
         except Exception as exc:  # pragma: no cover - runtime error surfaced to caller
             raise LLMError(f"llama.cpp generation failed: {exc}") from exc
 
+        if hasattr(response, "model_dump"):
+            response = response.model_dump()
+        elif hasattr(response, "dict"):
+            response = response.dict()
         if not isinstance(response, dict):
             raise LLMError("unexpected response from llama.cpp")
         choices = response.get("choices") or []

--- a/scripts/run_generator_local.py
+++ b/scripts/run_generator_local.py
@@ -1,0 +1,50 @@
+"""CLI helper that targets a locally hosted llama.cpp checkpoint."""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from scripts.run_generator import main
+
+DEFAULT_MODEL_PATH = Path.home() / ".llama" / "checkpoints" / "Llama-4-Scout-17B-16E-Instruct"
+
+
+def _preflight(args: argparse.Namespace) -> None:
+    if args.backend and args.backend not in {"local", "local-llama", "llama"}:
+        raise RuntimeError("run_generator_local.py only supports the local-llama backend")
+    args.backend = "local-llama"
+    model_path = args.model or os.getenv("LLAMA_MODEL_PATH") or str(DEFAULT_MODEL_PATH)
+    resolved = Path(model_path).expanduser()
+    if resolved.is_dir():
+        ggufs = sorted(resolved.glob("*.gguf"))
+        if not ggufs:
+            raise RuntimeError(
+                "no GGUF checkpoints found in directory. Point --model to the .gguf file"
+                f" inside {resolved}."
+            )
+        resolved = ggufs[0]
+    elif not resolved.exists():
+        raise RuntimeError(
+            "local model checkpoint not found. Set --model or LLAMA_MODEL_PATH to the GGUF file"
+            f" (expected at {resolved})."
+        )
+    try:
+        import llama_cpp  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - import error surfaces to user
+        raise RuntimeError(
+            "llama-cpp-python is not installed. Install it with `pip install llama-cpp-python`."
+        ) from exc
+    args.model = str(resolved)
+
+
+def cli() -> int:
+    return main(
+        default_backend="local-llama",
+        default_model=str(DEFAULT_MODEL_PATH),
+        preflight=_preflight,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli())

--- a/scripts/run_generator_local.py
+++ b/scripts/run_generator_local.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 from pathlib import Path
 
-from scripts.run_generator import main
+if __package__ is None or __package__ == "":
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from scripts.run_generator import main
+else:  # pragma: no cover - import guard is runtime dependent
+    from .run_generator import main
 
 DEFAULT_MODEL_PATH = Path.home() / ".llama" / "checkpoints" / "Llama-4-Scout-17B-16E-Instruct"
 

--- a/scripts/run_generator_openai.py
+++ b/scripts/run_generator_openai.py
@@ -1,0 +1,12 @@
+"""CLI helper that targets the OpenAI backend explicitly."""
+from __future__ import annotations
+
+from scripts.run_generator import main
+
+
+def cli() -> int:
+    return main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli())

--- a/tests/test_local_backend.py
+++ b/tests/test_local_backend.py
@@ -1,0 +1,43 @@
+import sys
+from argparse import Namespace
+from types import ModuleType
+
+import pytest
+
+from llm_backends import LLMError, LocalLlamaLLM
+from scripts.run_generator_local import _preflight
+
+
+def test_local_llm_requires_model_path(monkeypatch):
+    monkeypatch.delenv("LLAMA_MODEL_PATH", raising=False)
+    with pytest.raises(LLMError):
+        LocalLlamaLLM()
+
+
+def test_local_llm_accepts_explicit_file(tmp_path):
+    dummy = tmp_path / "model.gguf"
+    dummy.write_text("test")
+    llm = LocalLlamaLLM(model=str(dummy))
+    assert llm.model == str(dummy)
+    assert llm.model_path == dummy
+
+
+def test_preflight_validates_and_discovers_model(tmp_path, monkeypatch):
+    module = ModuleType("llama_cpp")
+    monkeypatch.setitem(sys.modules, "llama_cpp", module)
+    folder = tmp_path / "modeldir"
+    folder.mkdir()
+    gguf = folder / "model.gguf"
+    gguf.write_text("dummy")
+    args = Namespace(backend=None, model=str(folder))
+    _preflight(args)
+    assert args.backend == "local-llama"
+    assert args.model == str(gguf)
+
+
+def test_preflight_rejects_wrong_backend(monkeypatch):
+    module = ModuleType("llama_cpp")
+    monkeypatch.setitem(sys.modules, "llama_cpp", module)
+    args = Namespace(backend="openai", model=None)
+    with pytest.raises(RuntimeError):
+        _preflight(args)


### PR DESCRIPTION
## Summary
- add a llama.cpp-powered `local-llama` backend with robust error surfacing
- split the generator helper into OpenAI and local CLI entry points with preflight checks
- document the new workflows and cover the local backend setup with tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68da76fbcb64832db5bf884d3f016c11