### PR TITLE
Fix run_generator_local import for script execution

### DIFF
--- a/scripts/run_generator_local.py
+++ b/scripts/run_generator_local.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 from pathlib import Path
 
-from scripts.run_generator import main
+if __package__ is None or __package__ == "":
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from scripts.run_generator import main
+else:  # pragma: no cover - import guard is runtime dependent
+    from .run_generator import main
 
 DEFAULT_MODEL_PATH = Path.home() / ".llama" / "checkpoints" / "Llama-4-Scout-17B-16E-Instruct"
 


### PR DESCRIPTION
## Summary
- add a runtime import guard for scripts.run_generator so the module works when executed directly
- extend sys.path when run as a script to locate the package module

## Testing
- python scripts/run_generator_local.py --help

------
https://chatgpt.com/codex/tasks/task_e_68daeb408cb4832d90d69924bef7c4d2