### PR TITLE
Implement all 10 architecture phases for ductape code generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest tests/ -v
+
+      - name: Generate adapters
+        run: ductape generate --config variants/reference_project/config.yaml --output build/
+
+      - name: Check field_provenance.json exists
+        run: test -f build/field_provenance.json
+
+      - name: Compile generated C++
+        run: g++ -c build/converters/generated/*.cpp -Ibuild -Iruntime_reference -Ibuild/converters/generated -std=c++17
+
+      - name: Verify golden files
+        run: ductape verify --config variants/reference_project/config.yaml --expected variants/reference_project/expected_output/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+ductape.egg-info/
+build/
+__pycache__/
+*.pyc
+.pytest_cache/
+*.o

--- a/ductape/__init__.py
+++ b/ductape/__init__.py
@@ -1,0 +1,1 @@
+"""ductape - Universal Schema Adapter Generator"""

--- a/ductape/__main__.py
+++ b/ductape/__main__.py
@@ -1,0 +1,4 @@
+from ductape.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/ductape/cli.py
+++ b/ductape/cli.py
@@ -1,0 +1,31 @@
+import argparse
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="ductape",
+        description="Universal Schema Adapter Generator",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    gen_parser = subparsers.add_parser("generate", help="Generate adapter code")
+    gen_parser.add_argument("--config", required=True, help="Path to config.yaml")
+    gen_parser.add_argument("--output", required=True, help="Output directory")
+
+    verify_parser = subparsers.add_parser("verify", help="Verify against golden files")
+    verify_parser.add_argument("--config", required=True, help="Path to config.yaml")
+    verify_parser.add_argument("--expected", required=True, help="Expected output directory")
+
+    args = parser.parse_args()
+
+    if args.command is None:
+        parser.print_help()
+        sys.exit(0)
+
+    if args.command == "generate":
+        from ductape.codegen import run_generate
+        run_generate(args.config, args.output)
+    elif args.command == "verify":
+        from ductape.codegen import run_verify
+        run_verify(args.config, args.expected)

--- a/ductape/codegen.py
+++ b/ductape/codegen.py
@@ -1,0 +1,440 @@
+"""Generation driver - top-level orchestrator."""
+
+import os
+import json
+from ductape.config import load_config
+from ductape.conv.type_registry import TypeRegistry
+from ductape.conv.code_writer import CodeWriter
+from ductape.conv.converter import Converter
+
+
+def run_generate(config_path, output_dir):
+    """Run the full generation pipeline."""
+    config = load_config(config_path)
+    registry = TypeRegistry(config)
+    registry.load_all()
+
+    sentinel = config['project'].get('generic_version_sentinel', 9999)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Generate data type headers
+    for type_name, dt in registry.data_types.items():
+        _generate_data_type_header(dt, sentinel, output_dir, registry)
+
+    # Generate converter files
+    for type_name, dt in registry.data_types.items():
+        _generate_converter(dt, config, output_dir)
+
+    # Generate factory file
+    _generate_factory(registry.data_types, output_dir)
+
+    # Generate field provenance
+    _generate_field_provenance(registry, output_dir)
+
+    # Copy platform_types.h to output
+    _copy_platform_types(config, output_dir)
+
+    print(f"Generation complete. Output in {output_dir}")
+
+
+def _generate_data_type_header(dt, sentinel, output_dir, registry):
+    """Generate data_types/<TypeName>.h with all version namespaces."""
+    w = CodeWriter()
+    w.line("#pragma once")
+    w.line('#include "platform_types.h"')
+    w.line()
+
+    # Static assert guard - only active when the version macro is defined
+    w.line(f"#ifdef {dt.version_macro}")
+    w.line(f"static_assert({dt.version_macro} != {sentinel},")
+    w.line(f'  "Version {sentinel} is reserved as the generic adapter hub version");')
+    w.line(f"#endif")
+    w.line()
+
+    # Get all version containers for struct member type resolution
+    all_versions = sorted(dt.versions.keys())
+
+    # Generate namespace for each version
+    for ver_num in all_versions:
+        dtv = dt.versions[ver_num]
+        _generate_version_namespace(w, dt, dtv, ver_num, registry)
+
+    # Generate generic version namespace
+    if dt.generic:
+        _generate_version_namespace(w, dt, dt.generic, sentinel, registry, is_generic=True)
+
+    filepath = os.path.join(output_dir, "data_types", f"{dt.name}.h")
+    w.write_to(filepath)
+
+
+def _generate_version_namespace(w, dt, dtv, version, registry, is_generic=False):
+    """Generate one namespace block for a version."""
+    ns = dtv.namespace
+    w.block_open(f"namespace {ns}")
+    w.line(f"static const uint32_t VERSION = {version};")
+
+    # Check if we need to emit dependent struct types (like BatteryInfo_t)
+    # that are used as member types
+    emitted_types = set()
+    _emit_dependent_types(w, dtv, dt.name, emitted_types, registry)
+
+    w.line()
+    w.line(f"typedef struct")
+    w.block_open()
+    for member in dtv.ctype.members:
+        dim_str = ''.join(f'[{d}]' for d in member.dimensions)
+        w.line(f"{member.type_name} {member.name}{dim_str};")
+    w.block_close(f" {dt.name};")
+    w.block_close(f" // namespace {ns}")
+    w.line()
+
+
+def _emit_dependent_types(w, dtv, parent_name, emitted, registry):
+    """Emit struct types used as members that aren't the parent type."""
+    for member in dtv.ctype.members:
+        type_name = member.type_name
+        if type_name == parent_name or type_name in emitted:
+            continue
+        # Check if it's a struct type we know about
+        if member.is_struct or _is_known_struct(type_name, registry):
+            # Find the struct definition
+            struct_def = _find_struct_def(type_name, registry)
+            if struct_def:
+                emitted.add(type_name)
+                w.line()
+                w.line(f"typedef struct")
+                w.block_open()
+                for sm in struct_def.members:
+                    dim_str = ''.join(f'[{d}]' for d in sm.dimensions)
+                    w.line(f"{sm.type_name} {sm.name}{dim_str};")
+                w.block_close(f" {type_name};")
+
+
+def _is_known_struct(type_name, registry):
+    """Check if a type is a known struct across any version."""
+    for dt in registry.data_types.values():
+        for dtv in dt.versions.values():
+            for m in dtv.ctype.members:
+                if m.type_name == type_name and m.is_struct:
+                    return True
+    # Check the parsed containers
+    for iv in registry.interface_versions:
+        if type_name in iv.container.types:
+            ct = iv.container.types[type_name]
+            if ct.is_struct:
+                return True
+    return False
+
+
+def _find_struct_def(type_name, registry):
+    """Find the struct definition for a type name."""
+    for iv in registry.interface_versions:
+        if type_name in iv.container.types:
+            ct = iv.container.types[type_name]
+            if ct.is_struct:
+                return ct
+    return None
+
+
+def _generate_converter(dt, config, output_dir):
+    """Generate Converter_<TypeName>.h and .cpp."""
+    sentinel = config['project'].get('generic_version_sentinel', 9999)
+    conv = Converter(dt, config)
+
+    # Generate header
+    _generate_converter_header(dt, config, output_dir, conv)
+
+    # Generate implementation
+    _generate_converter_impl(dt, config, output_dir, conv)
+
+
+def _generate_converter_header(dt, config, output_dir, conv):
+    """Generate Converter_<TypeName>.h"""
+    w = CodeWriter()
+    w.line("#pragma once")
+    w.line()
+    w.line('#include "adapter_base.h"')
+    w.line('#include "version_info.h"')
+    w.line(f'#include "data_types/{dt.name}.h"')
+    w.line()
+
+    w.block_open(f"class Converter_{dt.name} : public AdapterConverterBase")
+    w.line("public:")
+    w.indent()
+    w.line(f'static const char* GetConverterTypeName() {{ return "{dt.name}"; }}')
+    w.line(f"static AdapterConverterBase* Create() {{ return new Converter_{dt.name}(); }}")
+    w.line()
+    w.line(f'const char* GetTypeName() const override {{ return "{dt.name}"; }}')
+    w.line()
+    w.line("long ConvertData(")
+    w.indent()
+    w.line("uint32_t src_type_tag, unsigned long src_size,")
+    w.line("const IVersionInfo& src_version,")
+    w.line("uint32_t dst_type_tag, unsigned long dst_size,")
+    w.line("const IVersionInfo* dst_version,")
+    w.line("void* dst_data,")
+    w.line("void** out_data, unsigned long& out_size) override;")
+    w.dedent()
+    w.line()
+    w.line("long GetDefaultValue(")
+    w.indent()
+    w.line("uint32_t type_tag, unsigned long size,")
+    w.line("const IVersionInfo& version,")
+    w.line("void** default_data, unsigned long& default_size) override;")
+    w.dedent()
+    w.line()
+    w.line("bool AreVersionsCompatible(")
+    w.indent()
+    w.line("uint32_t src_type_tag, unsigned long src_size,")
+    w.line("const IVersionInfo& src_version,")
+    w.line("uint32_t dst_type_tag, unsigned long dst_size,")
+    w.line("const IVersionInfo& dst_version) override;")
+    w.dedent()
+    w.dedent()
+    w.line()
+    w.line("private:")
+    w.indent()
+
+    # Forward converter declarations
+    for ver_num in sorted(dt.versions.keys()):
+        dtv = dt.versions[ver_num]
+        if conv.are_structurally_identical(dtv, dt.generic):
+            continue
+        gen_ns = dt.generic.namespace
+        src_ns = dtv.namespace
+        w.line(f"void convert_V{ver_num}_to_Generic(")
+        w.indent()
+        w.line(f"{gen_ns}::{dt.name}& dest,")
+        w.line(f"const {src_ns}::{dt.name}& source);")
+        w.dedent()
+
+    # Reverse converter declarations
+    if dt.generate_reverse:
+        for ver_num in sorted(dt.versions.keys()):
+            dtv = dt.versions[ver_num]
+            if conv.are_structurally_identical(dtv, dt.generic):
+                continue
+            gen_ns = dt.generic.namespace
+            dst_ns = dtv.namespace
+            w.line(f"void convert_Generic_to_V{ver_num}(")
+            w.indent()
+            w.line(f"{dst_ns}::{dt.name}& dest,")
+            w.line(f"const {gen_ns}::{dt.name}& source);")
+            w.dedent()
+
+    w.dedent()
+    w.block_close(";")
+
+    filepath = os.path.join(output_dir, "converters", "generated", f"Converter_{dt.name}.h")
+    w.write_to(filepath)
+
+
+def _generate_converter_impl(dt, config, output_dir, conv):
+    """Generate Converter_<TypeName>.cpp"""
+    w = CodeWriter()
+    w.line(f'#include "Converter_{dt.name}.h"')
+    w.line("#include <cstring>")
+    w.line()
+
+    sentinel = config['project'].get('generic_version_sentinel', 9999)
+
+    # ConvertData implementation
+    w.line(f"long Converter_{dt.name}::ConvertData(")
+    w.indent()
+    w.line("uint32_t src_type_tag, unsigned long src_size,")
+    w.line("const IVersionInfo& src_version,")
+    w.line("uint32_t dst_type_tag, unsigned long dst_size,")
+    w.line("const IVersionInfo* dst_version,")
+    w.line("void* dst_data,")
+    w.line("void** out_data, unsigned long& out_size)")
+    w.dedent()
+    w.block_open()
+    w.line("uint32_t src_ver = src_version.GetVersion();")
+    w.line(f"{dt.generic.namespace}::{dt.name} generic;")
+    w.line()
+
+    w.line("// Forward: source version -> generic")
+    w.line("switch (src_ver)")
+    w.block_open()
+    for ver_num in sorted(dt.versions.keys()):
+        dtv = dt.versions[ver_num]
+        if conv.are_structurally_identical(dtv, dt.generic):
+            w.line(f"case {ver_num}:")
+            w.indent()
+            w.line(f"memcpy(&generic, dst_data, sizeof(generic));")
+            w.line("break;")
+            w.dedent()
+        else:
+            w.line(f"case {ver_num}:")
+            w.indent()
+            w.line(f"convert_V{ver_num}_to_Generic(generic, *reinterpret_cast<const {dtv.namespace}::{dt.name}*>(dst_data));")
+            w.line("break;")
+            w.dedent()
+    w.line("default:")
+    w.indent()
+    w.line("return -1;")
+    w.dedent()
+    w.block_close()
+    w.line()
+
+    w.line("// Output generic")
+    w.line(f"out_size = sizeof({dt.generic.namespace}::{dt.name});")
+    w.line(f"*out_data = new {dt.generic.namespace}::{dt.name}(generic);")
+    w.line("return 0;")
+    w.block_close()
+    w.line()
+
+    # GetDefaultValue
+    w.line(f"long Converter_{dt.name}::GetDefaultValue(")
+    w.indent()
+    w.line("uint32_t type_tag, unsigned long size,")
+    w.line("const IVersionInfo& version,")
+    w.line("void** default_data, unsigned long& default_size)")
+    w.dedent()
+    w.block_open()
+    w.line(f"{dt.generic.namespace}::{dt.name} def;")
+    w.line("memset(&def, 0, sizeof(def));")
+    w.line(f"default_size = sizeof({dt.generic.namespace}::{dt.name});")
+    w.line(f"*default_data = new {dt.generic.namespace}::{dt.name}(def);")
+    w.line("return 0;")
+    w.block_close()
+    w.line()
+
+    # AreVersionsCompatible
+    w.line(f"bool Converter_{dt.name}::AreVersionsCompatible(")
+    w.indent()
+    w.line("uint32_t src_type_tag, unsigned long src_size,")
+    w.line("const IVersionInfo& src_version,")
+    w.line("uint32_t dst_type_tag, unsigned long dst_size,")
+    w.line("const IVersionInfo& dst_version)")
+    w.dedent()
+    w.block_open()
+    w.line("return src_version.GetVersion() == dst_version.GetVersion();")
+    w.block_close()
+    w.line()
+
+    # Forward converter implementations
+    for ver_num in sorted(dt.versions.keys()):
+        dtv = dt.versions[ver_num]
+        if conv.are_structurally_identical(dtv, dt.generic):
+            continue
+        gen_ns = dt.generic.namespace
+        src_ns = dtv.namespace
+        w.line(f"void Converter_{dt.name}::convert_V{ver_num}_to_Generic(")
+        w.indent()
+        w.line(f"{gen_ns}::{dt.name}& dest,")
+        w.line(f"const {src_ns}::{dt.name}& source)")
+        w.dedent()
+        w.block_open()
+        conv.generate_forward_body(dtv, w)
+        w.block_close()
+        w.line()
+
+    # Reverse converter implementations
+    if dt.generate_reverse:
+        for ver_num in sorted(dt.versions.keys()):
+            dtv = dt.versions[ver_num]
+            if conv.are_structurally_identical(dtv, dt.generic):
+                continue
+            gen_ns = dt.generic.namespace
+            dst_ns = dtv.namespace
+            w.line(f"void Converter_{dt.name}::convert_Generic_to_V{ver_num}(")
+            w.indent()
+            w.line(f"{dst_ns}::{dt.name}& dest,")
+            w.line(f"const {gen_ns}::{dt.name}& source)")
+            w.dedent()
+            w.block_open()
+            conv.generate_reverse_body(dtv, w)
+            w.block_close()
+            w.line()
+
+    filepath = os.path.join(output_dir, "converters", "generated", f"Converter_{dt.name}.cpp")
+    w.write_to(filepath)
+
+
+def _generate_factory(data_types, output_dir):
+    """Generate converters.cpp factory registration."""
+    w = CodeWriter()
+    w.line("#include <vector>")
+    w.line("#include <string>")
+    w.line("#include <functional>")
+    for name in sorted(data_types.keys()):
+        w.line(f'#include "Converter_{name}.h"')
+    w.line()
+
+    w.block_open("struct ConverterRegistration")
+    w.line("std::string type_name;")
+    w.line("std::function<AdapterConverterBase*()> factory;")
+    w.block_close(";")
+    w.line()
+
+    w.block_open("std::vector<ConverterRegistration> GetGeneratedAdapters()")
+    w.line("return {")
+    w.indent()
+    names = sorted(data_types.keys())
+    for i, name in enumerate(names):
+        comma = "," if i < len(names) - 1 else ""
+        w.line(f"{{ Converter_{name}::GetConverterTypeName(),")
+        w.line(f"  Converter_{name}::Create }}{comma}")
+    w.dedent()
+    w.line("};")
+    w.block_close()
+
+    filepath = os.path.join(output_dir, "converters", "generated", "converters.cpp")
+    w.write_to(filepath)
+
+
+def _generate_field_provenance(registry, output_dir):
+    """Generate field_provenance.json."""
+    from ductape.conv.field_provenance import generate_provenance
+    provenance = generate_provenance(registry)
+    filepath = os.path.join(output_dir, "field_provenance.json")
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+    with open(filepath, 'w') as f:
+        json.dump(provenance, f, indent=2)
+
+
+def _copy_platform_types(config, output_dir):
+    """Copy platform_types.h to data_types output."""
+    base_dir = config['_config_dir']
+    for inc_dir in config.get('additional_includes', []):
+        src_path = os.path.join(base_dir, inc_dir, 'platform_types.h')
+        if os.path.isfile(src_path):
+            dst_path = os.path.join(output_dir, 'data_types', 'platform_types.h')
+            os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+            with open(src_path) as f:
+                content = f.read()
+            with open(dst_path, 'w') as f:
+                f.write(content)
+            break
+
+
+def run_verify(config_path, expected_dir):
+    """Verify generated output against expected golden files."""
+    import tempfile
+    import filecmp
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_generate(config_path, tmpdir)
+
+        # Compare all files
+        differences = []
+        for dirpath, dirnames, filenames in os.walk(expected_dir):
+            for fname in filenames:
+                expected_file = os.path.join(dirpath, fname)
+                rel_path = os.path.relpath(expected_file, expected_dir)
+                generated_file = os.path.join(tmpdir, rel_path)
+
+                if not os.path.isfile(generated_file):
+                    differences.append(f"Missing: {rel_path}")
+                elif not filecmp.cmp(expected_file, generated_file, shallow=False):
+                    differences.append(f"Differs: {rel_path}")
+
+        if differences:
+            print("Verification FAILED:")
+            for d in differences:
+                print(f"  {d}")
+            raise SystemExit(1)
+        else:
+            print("Verification PASSED: all files match.")

--- a/ductape/config.py
+++ b/ductape/config.py
@@ -1,0 +1,81 @@
+"""YAML config loader with validation."""
+
+import yaml
+import os
+
+
+REQUIRED_TOP_LEVEL = {'project', 'header_sources', 'types'}
+REQUIRED_PROJECT = {'name'}
+
+
+class ConfigError(Exception):
+    pass
+
+
+def load_config(config_path):
+    """Load and validate a config YAML file."""
+    if not os.path.isfile(config_path):
+        raise ConfigError(f"Config file not found: {config_path}")
+
+    with open(config_path, 'r') as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        raise ConfigError("Config must be a YAML mapping")
+
+    _validate(data, config_path)
+
+    # Set defaults
+    data.setdefault('handcrafted', [])
+    data.setdefault('additional_includes', [])
+    data.setdefault('warnings', {'min_display_severity': 1, 'color': True})
+    data.setdefault('preprocessor', {'type': 'builtin'})
+    data['project'].setdefault('generic_version_sentinel', 9999)
+    data['project'].setdefault('description', '')
+
+    # Ensure type configs have defaults
+    for type_name, type_cfg in data['types'].items():
+        type_cfg.setdefault('defaults', {})
+        type_cfg.setdefault('renames', {})
+        type_cfg.setdefault('field_warnings', {})
+        type_cfg.setdefault('generate_reverse', False)
+
+    # Resolve paths relative to config file
+    data['_config_dir'] = os.path.dirname(os.path.abspath(config_path))
+
+    return data
+
+
+def _validate(data, config_path):
+    missing = REQUIRED_TOP_LEVEL - set(data.keys())
+    if missing:
+        raise ConfigError(f"Missing required top-level keys: {missing}")
+
+    if not isinstance(data['project'], dict):
+        raise ConfigError("'project' must be a mapping")
+
+    missing_proj = REQUIRED_PROJECT - set(data['project'].keys())
+    if missing_proj:
+        raise ConfigError(f"Missing required project keys: {missing_proj}")
+
+    if not isinstance(data['header_sources'], list):
+        raise ConfigError("'header_sources' must be a list")
+
+    if len(data['header_sources']) == 0:
+        raise ConfigError("'header_sources' must not be empty")
+
+    for i, src in enumerate(data['header_sources']):
+        if not isinstance(src, dict) or 'path' not in src or 'version_tag' not in src:
+            raise ConfigError(f"header_sources[{i}] must have 'path' and 'version_tag'")
+
+    if not isinstance(data['types'], dict):
+        raise ConfigError("'types' must be a mapping")
+
+    if len(data['types']) == 0:
+        raise ConfigError("'types' must not be empty")
+
+    for type_name, type_cfg in data['types'].items():
+        if not isinstance(type_cfg, dict):
+            raise ConfigError(f"types.{type_name} must be a mapping")
+        if 'version_macro' not in type_cfg:
+            raise ConfigError(f"types.{type_name} missing 'version_macro'")

--- a/ductape/conv/__init__.py
+++ b/ductape/conv/__init__.py
@@ -1,0 +1,1 @@
+"""Core parsing + generation engine."""

--- a/ductape/conv/code_writer.py
+++ b/ductape/conv/code_writer.py
@@ -1,0 +1,42 @@
+"""Low-level file writer with indentation tracking."""
+
+import os
+
+
+class CodeWriter:
+    """C++ file writer with indent tracking."""
+
+    def __init__(self, indent_str="  "):
+        self.indent_str = indent_str
+        self.indent_level = 0
+        self.lines = []
+
+    def line(self, text=""):
+        if text:
+            self.lines.append(self.indent_str * self.indent_level + text)
+        else:
+            self.lines.append("")
+
+    def indent(self):
+        self.indent_level += 1
+
+    def dedent(self):
+        self.indent_level = max(0, self.indent_level - 1)
+
+    def block_open(self, text=""):
+        if text:
+            self.line(text)
+        self.line("{")
+        self.indent()
+
+    def block_close(self, suffix=""):
+        self.dedent()
+        self.line("}" + suffix)
+
+    def get_content(self):
+        return '\n'.join(self.lines) + '\n'
+
+    def write_to(self, filepath):
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        with open(filepath, 'w') as f:
+            f.write(self.get_content())

--- a/ductape/conv/converter.py
+++ b/ductape/conv/converter.py
@@ -1,0 +1,145 @@
+"""Generates field-level conversion function bodies."""
+
+from ductape.conv.code_writer import CodeWriter
+
+
+class Converter:
+    """Generates C++ conversion function bodies between struct versions."""
+
+    def __init__(self, data_type, config):
+        self.data_type = data_type
+        self.config = config
+        self.renames = data_type.renames  # old_name -> new_name
+        self.reverse_renames = {v: k for k, v in self.renames.items()}
+        self.defaults = data_type.defaults
+
+    def are_structurally_identical(self, src_dtv, dst_dtv):
+        """Check if two versions are structurally identical (FR-08)."""
+        src_members = src_dtv.ctype.members
+        dst_members = dst_dtv.ctype.members
+        if len(src_members) != len(dst_members):
+            return False
+        for sm, dm in zip(src_members, dst_members):
+            if sm.name != dm.name:
+                return False
+            if sm.type_name != dm.type_name:
+                return False
+            if sm.dimensions != dm.dimensions:
+                return False
+        return True
+
+    def generate_forward_body(self, src_dtv, writer):
+        """Generate V_N -> Generic conversion body."""
+        generic = self.data_type.generic
+        if not generic:
+            return
+
+        writer.line(f"memset(&dest, 0, sizeof(dest));")
+
+        for dst_member in generic.ctype.members:
+            dst_name = dst_member.name
+            # Find source field name (may be renamed)
+            src_name = self._find_src_field(dst_name, src_dtv)
+
+            if src_name is not None:
+                self._generate_field_copy(writer, src_name, dst_name,
+                                          dst_member, src_dtv, generic)
+            else:
+                # Field doesn't exist in source - apply default if available
+                self._generate_default(writer, dst_name, dst_member)
+
+    def generate_reverse_body(self, dst_dtv, writer):
+        """Generate Generic -> V_N conversion body."""
+        generic = self.data_type.generic
+        if not generic:
+            return
+
+        writer.line(f"memset(&dest, 0, sizeof(dest));")
+
+        for dst_member in dst_dtv.ctype.members:
+            dst_name = dst_member.name
+            # Find the generic field name (may have been renamed)
+            generic_name = self.renames.get(dst_name, dst_name)
+
+            # Check if this generic field exists
+            generic_member = None
+            for gm in generic.ctype.members:
+                if gm.name == generic_name:
+                    generic_member = gm
+                    break
+
+            if generic_member is not None:
+                self._generate_field_copy(writer, generic_name, dst_name,
+                                          dst_member, generic, dst_dtv)
+            else:
+                self._generate_default(writer, dst_name, dst_member)
+
+    def _find_src_field(self, dst_name, src_dtv):
+        """Find the source field name for a destination field."""
+        # Check if dst_name exists directly in source
+        for m in src_dtv.ctype.members:
+            if m.name == dst_name:
+                return dst_name
+
+        # Check reverse rename: if dst_name was renamed from something
+        old_name = self.reverse_renames.get(dst_name)
+        if old_name:
+            for m in src_dtv.ctype.members:
+                if m.name == old_name:
+                    return old_name
+
+        return None
+
+    def _find_member(self, name, dtv):
+        """Find a member by name in a data type version."""
+        for m in dtv.ctype.members:
+            if m.name == name:
+                return m
+        return None
+
+    def _generate_field_copy(self, writer, src_name, dst_name, dst_member,
+                             src_dtv, dst_dtv):
+        """Generate field copy code."""
+        src_member = self._find_member(src_name, src_dtv)
+        if src_member is None:
+            return
+
+        if src_member.is_array and dst_member.is_array:
+            # Array copy with min dimension
+            src_dims = src_member.dimensions
+            dst_dims = dst_member.dimensions
+            if src_dims and dst_dims:
+                min_dim = f"({src_dims[0]} < {dst_dims[0]} ? {src_dims[0]} : {dst_dims[0]})"
+                if src_dims[0] == dst_dims[0]:
+                    min_dim = str(src_dims[0])
+                writer.line(f"for (int i = 0; i < {min_dim}; i++)")
+                writer.block_open()
+                writer.line(f"dest.{dst_name}[i] = source.{src_name}[i];")
+                writer.block_close()
+            else:
+                writer.line(f"dest.{dst_name} = source.{src_name};")
+        elif src_member.is_struct:
+            # Struct copy via memcpy (types are in different namespaces)
+            writer.line(f"memcpy(&dest.{dst_name}, &source.{src_name}, sizeof(dest.{dst_name}));")
+        else:
+            # Simple field copy
+            writer.line(f"dest.{dst_name} = source.{src_name};")
+
+    def _generate_default(self, writer, field_name, member):
+        """Generate default value assignment."""
+        # Look up default from flat dotted keys
+        default_val = self._find_default(field_name)
+        if default_val is not None:
+            if member.is_struct:
+                writer.line(f"// Default for struct field {field_name} (zero-initialized by memset)")
+            else:
+                writer.line(f"dest.{field_name} = {default_val};")
+        else:
+            writer.line(f"// Field '{field_name}' not in source, zero-initialized by memset")
+
+    def _find_default(self, field_name):
+        """Find default value from config defaults dict."""
+        # Direct match
+        if field_name in self.defaults:
+            return self.defaults[field_name]
+        return None

--- a/ductape/conv/data_type.py
+++ b/ductape/conv/data_type.py
@@ -1,0 +1,82 @@
+"""One logical type across all its versions."""
+
+from dataclasses import dataclass, field
+from typing import Optional
+from ductape.conv.data_type_version import DataTypeVersion
+from ductape.conv.typecontainer import CType, CTypeMember
+
+
+class GenericVersion:
+    """Tag class for the generic hub version."""
+    pass
+
+
+@dataclass
+class DataType:
+    """A logical data type with all its versions and a generic superset."""
+    name: str
+    version_macro: str
+    versions: dict = field(default_factory=dict)  # version_num -> DataTypeVersion
+    defaults: dict = field(default_factory=dict)
+    renames: dict = field(default_factory=dict)  # old_name -> new_name
+    field_warnings: dict = field(default_factory=dict)
+    generate_reverse: bool = False
+    generic: Optional[DataTypeVersion] = None
+
+    def add_version(self, version_num, ctype):
+        dtv = DataTypeVersion(
+            type_name=self.name,
+            version=version_num,
+            ctype=ctype,
+        )
+        self.versions[version_num] = dtv
+
+    def build_generic(self, sentinel=9999):
+        """Build the generic (superset) version from all known versions."""
+        all_members = {}  # name -> CTypeMember (keep last seen)
+        member_order = []
+
+        # Apply renames: old_name -> new_name
+        reverse_renames = {v: k for k, v in self.renames.items()}
+
+        for ver_num in sorted(self.versions.keys()):
+            dtv = self.versions[ver_num]
+            for member in dtv.ctype.members:
+                # Check if this member name has a rename
+                canonical_name = self.renames.get(member.name, member.name)
+                if canonical_name not in all_members:
+                    # Create member with canonical name
+                    gen_member = CTypeMember(
+                        name=canonical_name,
+                        type_name=member.type_name,
+                        is_array=member.is_array,
+                        dimensions=list(member.dimensions),
+                        is_struct=member.is_struct,
+                        is_enum=member.is_enum,
+                        is_basic_type=member.is_basic_type,
+                        bitfield_width=member.bitfield_width,
+                    )
+                    all_members[canonical_name] = gen_member
+                    member_order.append(canonical_name)
+                else:
+                    # Update dimensions to max
+                    existing = all_members[canonical_name]
+                    if member.dimensions:
+                        for i, dim in enumerate(member.dimensions):
+                            if i < len(existing.dimensions):
+                                existing.dimensions[i] = max(existing.dimensions[i], dim)
+                            else:
+                                existing.dimensions.append(dim)
+
+        generic_ctype = CType(
+            name=self.name,
+            is_struct=True,
+            members=[all_members[n] for n in member_order],
+        )
+        self.generic = DataTypeVersion(
+            type_name=self.name,
+            version=sentinel,
+            ctype=generic_ctype,
+            namespace=f"{self.name}_V_Gen",
+        )
+        return self.generic

--- a/ductape/conv/data_type_version.py
+++ b/ductape/conv/data_type_version.py
@@ -1,0 +1,18 @@
+"""One (type, version) tuple with struct layout."""
+
+from dataclasses import dataclass, field
+from typing import Optional
+from ductape.conv.typecontainer import CType
+
+
+@dataclass
+class DataTypeVersion:
+    """One version of one data type."""
+    type_name: str
+    version: int
+    ctype: CType
+    namespace: str = ""  # C++ namespace like TypeName_V_1
+
+    def __post_init__(self):
+        if not self.namespace:
+            self.namespace = f"{self.type_name}_V_{self.version}"

--- a/ductape/conv/expression_eval.py
+++ b/ductape/conv/expression_eval.py
@@ -1,0 +1,64 @@
+"""Constant integer expression evaluator."""
+
+import re
+
+
+class ExpressionEvaluator:
+    """Evaluate constant integer expressions with symbol substitution."""
+
+    def __init__(self, symbol_table=None):
+        self.symbols = dict(symbol_table) if symbol_table else {}
+
+    def add_symbol(self, name, value):
+        self.symbols[name] = value
+
+    def evaluate(self, expr):
+        """Evaluate an expression string to an integer, or return None."""
+        if expr is None or expr == '':
+            return None
+        try:
+            resolved = self._substitute_symbols(str(expr))
+            return self._eval_expr(resolved)
+        except Exception:
+            return None
+
+    def _substitute_symbols(self, expr):
+        """Replace known symbol names with their integer values."""
+        def replacer(m):
+            # Skip hex literals like 0xFF
+            start = m.start()
+            if start > 0 and expr[start - 1] in ('0',) and start >= 2 and expr[start - 1:start + 1].startswith('x'):
+                return m.group(0)
+            name = m.group(0)
+            if name in self.symbols:
+                val = self.symbols[name]
+                if isinstance(val, int):
+                    return str(val)
+                # Try to evaluate the symbol's value recursively
+                resolved = self._substitute_symbols(str(val))
+                result = self._eval_expr(resolved)
+                if result is not None:
+                    self.symbols[name] = result  # cache
+                    return str(result)
+                return str(val)
+            return name
+        # Use negative lookbehind to avoid matching hex suffixes like xFF in 0xFF
+        return re.sub(r'(?<![0-9x])\b[A-Za-z_]\w*', replacer, expr)
+
+    def _eval_expr(self, expr):
+        """Safely evaluate an integer expression."""
+        expr = expr.strip()
+        if not expr:
+            return None
+        # Only allow safe characters
+        if not re.match(r'^[\dA-Fa-fxX\s\+\-\*/%\(\)&\|~\^<>]+$', expr):
+            return None
+        try:
+            # Replace / with // for integer division (but not // which stays)
+            int_expr = re.sub(r'(?<!/)/(?!/)', '//', expr)
+            result = eval(int_expr, {"__builtins__": {}}, {})
+            if isinstance(result, (int, float, bool)):
+                return int(result)
+            return None
+        except Exception:
+            return None

--- a/ductape/conv/field_provenance.py
+++ b/ductape/conv/field_provenance.py
@@ -1,0 +1,94 @@
+"""Cross-version field audit + provenance report."""
+
+
+def generate_provenance(registry):
+    """Generate field provenance data for all types."""
+    provenance = {}
+
+    for type_name, dt in registry.data_types.items():
+        if dt.generic is None:
+            continue
+
+        type_prov = {}
+        reverse_renames = {v: k for k, v in dt.renames.items()}
+
+        for member in dt.generic.ctype.members:
+            field_name = member.name
+            field_info = {
+                "generic_type": member.type_name,
+                "versions": {},
+                "type_compatible": True,
+                "warnings": [],
+            }
+
+            field_types = set()
+            default_versions = []
+
+            for ver_num in sorted(dt.versions.keys()):
+                dtv = dt.versions[ver_num]
+                src_name = _find_field_in_version(field_name, dtv, dt.renames)
+
+                if src_name is not None:
+                    src_member = _get_member(src_name, dtv)
+                    if src_member:
+                        ver_entry = {
+                            "type": src_member.type_name,
+                            "field_name": src_name,
+                        }
+                        if src_name != field_name:
+                            ver_entry["rename_from"] = src_name
+                        field_info["versions"][str(ver_num)] = ver_entry
+                        field_types.add(src_member.type_name)
+                    else:
+                        field_info["versions"][str(ver_num)] = None
+                        default_versions.append(ver_num)
+                else:
+                    field_info["versions"][str(ver_num)] = None
+                    default_versions.append(ver_num)
+
+            if len(field_types) > 1:
+                field_info["type_compatible"] = False
+
+            if default_versions:
+                field_info["default_applied_for"] = default_versions
+
+            # Add field warnings from config
+            if field_name in dt.field_warnings:
+                fw = dt.field_warnings[field_name]
+                field_info["warnings"].append({
+                    "severity": fw.get("severity", 0),
+                    "note": fw.get("note", ""),
+                })
+
+            type_prov[field_name] = field_info
+
+        provenance[type_name] = type_prov
+
+    return provenance
+
+
+def _find_field_in_version(generic_name, dtv, renames):
+    """Find the source field name in a version."""
+    reverse_renames = {v: k for k, v in renames.items()}
+
+    # Direct match
+    for m in dtv.ctype.members:
+        if m.name == generic_name:
+            return generic_name
+
+    # Check reverse rename
+    old_name = reverse_renames.get(generic_name)
+    if old_name:
+        for m in dtv.ctype.members:
+            if m.name == old_name:
+                return old_name
+
+    return None
+
+
+def _get_member(name, dtv):
+    """Get a member by name from a data type version."""
+    for m in dtv.ctype.members:
+        if m.name == name:
+            return m
+    return None

--- a/ductape/conv/interface_version.py
+++ b/ductape/conv/interface_version.py
@@ -1,0 +1,57 @@
+"""One header package at one version -> TypeContainer."""
+
+import os
+from ductape.conv.parser import Parser
+
+
+class InterfaceVersion:
+    """Parse one header directory at one version into a TypeContainer."""
+
+    def __init__(self, base_dir, path, version_tag, additional_includes=None):
+        self.base_dir = base_dir
+        self.path = path
+        self.version_tag = version_tag
+        self.additional_includes = additional_includes or []
+        self.container = None
+        self.version_numbers = {}  # type_name -> version number
+
+    def parse(self, version_macros):
+        """Parse all .h files in the path directory.
+
+        Args:
+            version_macros: dict of type_name -> macro_name
+        Returns:
+            TypeContainer with all parsed types
+        """
+        header_dir = os.path.join(self.base_dir, self.path)
+        parser = Parser()
+
+        # Collect all header text
+        all_text = ""
+        for inc_dir in self.additional_includes:
+            inc_path = os.path.join(self.base_dir, inc_dir)
+            if os.path.isdir(inc_path):
+                for fname in sorted(os.listdir(inc_path)):
+                    if fname.endswith('.h'):
+                        fpath = os.path.join(inc_path, fname)
+                        with open(fpath) as f:
+                            all_text += f.read() + "\n"
+
+        if os.path.isdir(header_dir):
+            for fname in sorted(os.listdir(header_dir)):
+                if fname.endswith('.h'):
+                    fpath = os.path.join(header_dir, fname)
+                    with open(fpath) as f:
+                        all_text += f.read() + "\n"
+
+        self.container = parser.parse(all_text)
+
+        # Extract version numbers from defines
+        macro_to_type = {v: k for k, v in version_macros.items()}
+        for define_name, define_val in self.container.defines.items():
+            if define_name in macro_to_type:
+                type_name = macro_to_type[define_name]
+                if isinstance(define_val, int):
+                    self.version_numbers[type_name] = define_val
+
+        return self.container

--- a/ductape/conv/parser.py
+++ b/ductape/conv/parser.py
@@ -1,0 +1,370 @@
+"""Recursive-descent C parser -> TypeContainer."""
+
+from ductape.conv.preprocessor import Preprocessor
+from ductape.conv.expression_eval import ExpressionEvaluator
+from ductape.conv.tokenizer import Tokenizer, TokenType
+from ductape.conv.typecontainer import TypeContainer, CType, CTypeMember
+
+
+class Parser:
+    """Parse preprocessed C header text into a TypeContainer."""
+
+    def __init__(self):
+        self.warnings = []
+
+    def parse(self, source_text):
+        """Parse C header source text and return a TypeContainer."""
+        pp = Preprocessor()
+        clean_text = pp.process(source_text)
+
+        self.expr_eval = ExpressionEvaluator()
+        # Register defines
+        for name, value in pp.defines.items():
+            evaluated = self.expr_eval.evaluate(value)
+            if evaluated is not None:
+                self.expr_eval.add_symbol(name, evaluated)
+
+        self.container = TypeContainer()
+        # Add defines
+        for name, value in pp.defines.items():
+            evaluated = self.expr_eval.evaluate(value)
+            self.container.add_define(name, evaluated if evaluated is not None else value)
+
+        self.tokenizer = Tokenizer(clean_text)
+        self._parse_top_level()
+        return self.container
+
+    def _parse_top_level(self):
+        while not self.tokenizer.at_end():
+            tok = self.tokenizer.peek()
+            if tok.type == TokenType.Symbol and tok.value == 'typedef':
+                self._parse_typedef()
+            elif tok.type == TokenType.Symbol and tok.value == 'struct':
+                self._parse_cpp_struct()
+            elif tok.type == TokenType.Symbol and tok.value == 'enum':
+                self._parse_cpp_enum()
+            elif tok.type == TokenType.Special and tok.value == ';':
+                self.tokenizer.next()  # skip stray semicolons
+            else:
+                # Skip unknown tokens
+                self.tokenizer.next()
+
+    def _parse_typedef(self):
+        self.tokenizer.expect(TokenType.Symbol, 'typedef')
+        tok = self.tokenizer.peek()
+
+        if tok.type == TokenType.Symbol and tok.value == 'struct':
+            self._parse_typedef_struct()
+        elif tok.type == TokenType.Symbol and tok.value == 'enum':
+            self._parse_typedef_enum()
+        else:
+            self._parse_typedef_alias()
+
+    def _parse_typedef_struct(self):
+        self.tokenizer.expect(TokenType.Symbol, 'struct')
+        tok = self.tokenizer.peek()
+
+        # Optional tag name
+        tag_name = None
+        if tok.type == TokenType.Symbol and tok.value != '{':
+            next_tok = self.tokenizer.peek()
+            # Check if it's a tag (followed by {)
+            if next_tok.type == TokenType.Symbol:
+                # peek ahead more
+                saved = self.tokenizer._index
+                tag_tok = self.tokenizer.next()
+                if self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '{':
+                    tag_name = tag_tok.value
+                else:
+                    # Not a tag, restore
+                    self.tokenizer._index = saved
+
+        # Parse the struct body
+        if self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '{':
+            members = self._parse_struct_body()
+        else:
+            # Forward declaration or other
+            name = self.tokenizer.next().value
+            self.tokenizer.match(TokenType.Special, ';')
+            return
+
+        # Get the typedef name
+        name_tok = self.tokenizer.expect(TokenType.Symbol)
+        name = name_tok.value
+        self.tokenizer.expect(TokenType.Special, ';')
+
+        ctype = CType(
+            name=name,
+            is_struct=True,
+            members=members,
+        )
+        self.container.add_type(name, ctype)
+
+    def _parse_struct_body(self):
+        self.tokenizer.expect(TokenType.Special, '{')
+        members = []
+        while not (self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '}'):
+            if self.tokenizer.at_end():
+                break
+            member = self._parse_member()
+            if member is not None:
+                members.append(member)
+        self.tokenizer.expect(TokenType.Special, '}')
+        return members
+
+    def _parse_member(self):
+        tok = self.tokenizer.peek()
+
+        # Handle nested struct
+        if tok.type == TokenType.Symbol and tok.value == 'struct':
+            return self._parse_nested_struct_member()
+
+        # Handle nested enum
+        if tok.type == TokenType.Symbol and tok.value == 'enum':
+            self.tokenizer.next()
+            # Skip inline enum
+            if self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '{':
+                self._skip_braces()
+            name = self.tokenizer.next().value
+            self.tokenizer.match(TokenType.Special, ';')
+            return CTypeMember(name=name, type_name='int', is_enum=True)
+
+        # Skip qualifiers
+        while (self.tokenizer.peek().type == TokenType.Symbol and
+               self.tokenizer.peek().value in ('const', 'volatile', 'unsigned', 'signed', 'long')):
+            self.tokenizer.next()
+
+        # Read type name
+        if self.tokenizer.peek().type != TokenType.Symbol:
+            self.tokenizer.next()  # skip unexpected token
+            return None
+
+        type_name = self.tokenizer.next().value
+
+        # Handle pointer
+        while self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '*':
+            self.tokenizer.next()
+            type_name += '*'
+
+        # Read member name
+        if self.tokenizer.peek().type != TokenType.Symbol:
+            # Could be anonymous or error
+            self.tokenizer.match(TokenType.Special, ';')
+            return None
+
+        member_name = self.tokenizer.next().value
+
+        # Array dimensions
+        dimensions = []
+        while self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '[':
+            self.tokenizer.next()  # [
+            dim_str = self._read_until(']')
+            self.tokenizer.expect(TokenType.Special, ']')
+            dim = self.expr_eval.evaluate(dim_str)
+            if dim is not None:
+                dimensions.append(dim)
+
+        # Bitfield
+        bitfield_width = None
+        if self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == ':':
+            self.tokenizer.next()
+            width_tok = self.tokenizer.next()
+            bitfield_width = int(width_tok.value) if width_tok.value.isdigit() else None
+
+        self.tokenizer.match(TokenType.Special, ';')
+
+        is_basic = self.container.is_known_type(type_name) and self.container.get_type(type_name).is_basic_type
+        is_struct_type = self.container.is_known_type(type_name) and self.container.get_type(type_name).is_struct
+        # If not known yet but not basic, assume it might be a struct defined elsewhere
+        if not self.container.is_known_type(type_name):
+            is_basic = type_name in TypeContainer.BASIC_TYPES
+
+        return CTypeMember(
+            name=member_name,
+            type_name=type_name,
+            is_array=len(dimensions) > 0,
+            dimensions=dimensions,
+            is_struct=is_struct_type,
+            is_basic_type=is_basic,
+            bitfield_width=bitfield_width,
+        )
+
+    def _parse_nested_struct_member(self):
+        self.tokenizer.expect(TokenType.Symbol, 'struct')
+
+        # Optional tag
+        tag = None
+        if self.tokenizer.peek().type == TokenType.Symbol:
+            saved = self.tokenizer._index
+            tag_tok = self.tokenizer.next()
+            if self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '{':
+                tag = tag_tok.value
+            elif self.tokenizer.peek().type == TokenType.Symbol:
+                # struct TypeName member_name;
+                type_name = tag_tok.value
+                member_name = self.tokenizer.next().value
+                self.tokenizer.match(TokenType.Special, ';')
+                return CTypeMember(name=member_name, type_name=type_name, is_struct=True)
+            else:
+                self.tokenizer._index = saved
+
+        if self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '{':
+            members = self._parse_struct_body()
+            if self.tokenizer.peek().type == TokenType.Symbol:
+                member_name = self.tokenizer.next().value
+                self.tokenizer.match(TokenType.Special, ';')
+                return CTypeMember(name=member_name, type_name='struct', is_struct=True)
+            self.tokenizer.match(TokenType.Special, ';')
+            return None
+        return None
+
+    def _parse_typedef_enum(self):
+        self.tokenizer.expect(TokenType.Symbol, 'enum')
+
+        # Optional tag
+        if self.tokenizer.peek().type == TokenType.Symbol:
+            saved = self.tokenizer._index
+            tag_tok = self.tokenizer.next()
+            if not (self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '{'):
+                self.tokenizer._index = saved
+
+        enum_values = self._parse_enum_body()
+
+        name_tok = self.tokenizer.expect(TokenType.Symbol)
+        name = name_tok.value
+        self.tokenizer.expect(TokenType.Special, ';')
+
+        ctype = CType(
+            name=name,
+            is_enum=True,
+            enum_values=enum_values,
+        )
+        self.container.add_type(name, ctype)
+
+    def _parse_enum_body(self):
+        self.tokenizer.expect(TokenType.Special, '{')
+        values = []
+        counter = 0
+        while not (self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '}'):
+            if self.tokenizer.at_end():
+                break
+            name_tok = self.tokenizer.expect(TokenType.Symbol)
+            name = name_tok.value
+            if self.tokenizer.match(TokenType.Special, '='):
+                val_str = self._read_until(',', '}')
+                val = self.expr_eval.evaluate(val_str)
+                if val is not None:
+                    counter = val
+            values.append((name, counter))
+            counter += 1
+            self.tokenizer.match(TokenType.Special, ',')
+        self.tokenizer.expect(TokenType.Special, '}')
+        return values
+
+    def _parse_typedef_alias(self):
+        """Parse: typedef ExistingType NewAlias; or typedef Type ArrayAlias[N];"""
+        # Read the type name (may be multi-word like "unsigned char")
+        type_parts = [self.tokenizer.next().value]
+
+        # Consume additional type qualifiers/parts
+        while self.tokenizer.peek().type == TokenType.Symbol:
+            # Peek two ahead to see if the next-next is ; or [ (meaning current next is alias)
+            saved = self.tokenizer._index
+            candidate = self.tokenizer.next()
+            next_tok = self.tokenizer.peek()
+            if next_tok.type == TokenType.Special and next_tok.value in (';', '[', '*'):
+                # candidate is the alias name
+                self.tokenizer._index = saved
+                break
+            elif next_tok.type == TokenType.EOF:
+                self.tokenizer._index = saved
+                break
+            else:
+                # It's part of the type
+                self.tokenizer._index = saved
+                type_parts.append(self.tokenizer.next().value)
+
+        type_name = ' '.join(type_parts)
+
+        # Handle pointer
+        while self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '*':
+            self.tokenizer.next()
+            type_name += '*'
+
+        alias_name = self.tokenizer.expect(TokenType.Symbol).value
+
+        # Check for array dimensions
+        dimensions = []
+        while self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '[':
+            self.tokenizer.next()
+            dim_str = self._read_until(']')
+            self.tokenizer.expect(TokenType.Special, ']')
+            dim = self.expr_eval.evaluate(dim_str)
+            if dim is not None:
+                dimensions.append(dim)
+
+        self.tokenizer.expect(TokenType.Special, ';')
+
+        ctype = CType(
+            name=alias_name,
+            aliased_type=type_name,
+            is_array=len(dimensions) > 0,
+            dimensions=dimensions,
+        )
+        self.container.add_type(alias_name, ctype)
+
+    def _parse_cpp_struct(self):
+        """Parse: struct Name { ... };"""
+        self.tokenizer.expect(TokenType.Symbol, 'struct')
+
+        # Check for forward declaration
+        name_tok = self.tokenizer.expect(TokenType.Symbol)
+        name = name_tok.value
+
+        if self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == ';':
+            # Forward declaration
+            self.tokenizer.next()
+            return
+
+        if self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '{':
+            members = self._parse_struct_body()
+            self.tokenizer.expect(TokenType.Special, ';')
+            ctype = CType(name=name, is_struct=True, members=members)
+            self.container.add_type(name, ctype)
+
+    def _parse_cpp_enum(self):
+        """Parse: enum Name { ... };"""
+        self.tokenizer.expect(TokenType.Symbol, 'enum')
+        name_tok = self.tokenizer.expect(TokenType.Symbol)
+        name = name_tok.value
+
+        if self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '{':
+            enum_values = self._parse_enum_body()
+            self.tokenizer.expect(TokenType.Special, ';')
+            ctype = CType(name=name, is_enum=True, enum_values=enum_values)
+            self.container.add_type(name, ctype)
+
+    def _read_until(self, *stop_chars):
+        """Read tokens until a stop character, returning concatenated text."""
+        parts = []
+        while True:
+            tok = self.tokenizer.peek()
+            if tok.type == TokenType.EOF:
+                break
+            if tok.type == TokenType.Special and tok.value in stop_chars:
+                break
+            parts.append(self.tokenizer.next().value)
+        return ' '.join(parts)
+
+    def _skip_braces(self):
+        """Skip a brace-enclosed block."""
+        depth = 0
+        if self.tokenizer.peek().type == TokenType.Special and self.tokenizer.peek().value == '{':
+            self.tokenizer.next()
+            depth = 1
+        while depth > 0 and not self.tokenizer.at_end():
+            tok = self.tokenizer.next()
+            if tok.type == TokenType.Special and tok.value == '{':
+                depth += 1
+            elif tok.type == TokenType.Special and tok.value == '}':
+                depth -= 1

--- a/ductape/conv/pointers/__init__.py
+++ b/ductape/conv/pointers/__init__.py
@@ -1,0 +1,1 @@
+"""Pointer abstractions for struct tree navigation."""

--- a/ductape/conv/pointers/struct_pointer.py
+++ b/ductape/conv/pointers/struct_pointer.py
@@ -1,0 +1,125 @@
+"""Navigates into versioned struct members."""
+
+
+class AmbiguousMemberError(Exception):
+    """Raised when fuzzy lookup matches multiple candidates."""
+    pass
+
+
+class StructPointer:
+    """Wraps a CType + namespace for navigating struct members."""
+
+    def __init__(self, ctype, namespace, container=None, parent=None):
+        self.ctype = ctype
+        self.namespace = namespace
+        self.container = container
+        self._parent = parent
+        self._used = False
+
+    @property
+    def is_struct(self):
+        return self.ctype.is_struct
+
+    @property
+    def is_array(self):
+        return self.ctype.is_array
+
+    @property
+    def is_basic_type(self):
+        return self.ctype.is_basic_type
+
+    @property
+    def pass_able(self):
+        return True
+
+    @property
+    def parent_source(self):
+        return self._parent
+
+    @property
+    def array_dimensions(self):
+        return self.ctype.dimensions
+
+    def enter_struct(self, field_name, type_hint=None):
+        """Navigate into a named sub-field using 3-step fuzzy lookup."""
+        members = self.ctype.members if self.ctype.members else []
+
+        # Step 1: exact match
+        for m in members:
+            if m.name == field_name:
+                child_ctype = self._resolve_member_type(m)
+                return StructPointer(child_ctype, self.namespace,
+                                     self.container, parent=self)
+
+        # Step 2: name + "_" + type_hint match
+        if type_hint:
+            candidates = []
+            pattern = f"{field_name}_{type_hint}"
+            for m in members:
+                if m.name == pattern:
+                    candidates.append(m)
+            if len(candidates) == 1:
+                child_ctype = self._resolve_member_type(candidates[0])
+                return StructPointer(child_ctype, self.namespace,
+                                     self.container, parent=self)
+            elif len(candidates) > 1:
+                names = [c.name for c in candidates]
+                raise AmbiguousMemberError(
+                    f"Ambiguous match for '{field_name}' with hint '{type_hint}': {names}")
+
+        # Step 3: strip type suffix and retry
+        candidates = []
+        for m in members:
+            # Strip common suffixes
+            stripped = m.name
+            for suffix in ('_t', '_T', '_type'):
+                if stripped.endswith(suffix):
+                    stripped = stripped[:-len(suffix)]
+            if stripped == field_name:
+                candidates.append(m)
+
+        if len(candidates) == 1:
+            child_ctype = self._resolve_member_type(candidates[0])
+            return StructPointer(child_ctype, self.namespace,
+                                 self.container, parent=self)
+        elif len(candidates) > 1:
+            names = [c.name for c in candidates]
+            raise AmbiguousMemberError(
+                f"Ambiguous match for '{field_name}': {names}")
+
+        return None
+
+    def enter_array(self, dest=None):
+        """Navigate into array element."""
+        if not self.ctype.is_array:
+            return None
+        from ductape.conv.typecontainer import CType
+        elem_type = CType(
+            name=self.ctype.name,
+            is_basic_type=self.ctype.is_basic_type,
+            is_struct=self.ctype.is_struct,
+            members=self.ctype.members,
+        )
+        return StructPointer(elem_type, self.namespace, self.container, parent=self)
+
+    def _resolve_member_type(self, member):
+        """Create a CType for a member."""
+        from ductape.conv.typecontainer import CType
+        if self.container and member.type_name in self.container.types:
+            ct = self.container.types[member.type_name]
+            return CType(
+                name=member.type_name,
+                is_struct=ct.is_struct,
+                is_enum=ct.is_enum,
+                is_basic_type=ct.is_basic_type,
+                is_array=member.is_array,
+                dimensions=list(member.dimensions),
+                members=ct.members,
+            )
+        return CType(
+            name=member.type_name,
+            is_basic_type=member.is_basic_type,
+            is_struct=member.is_struct,
+            is_array=member.is_array,
+            dimensions=list(member.dimensions),
+        )

--- a/ductape/conv/pointers/value_pointer.py
+++ b/ductape/conv/pointers/value_pointer.py
@@ -1,0 +1,47 @@
+"""Default/override value pointer."""
+
+
+class ValuePointer:
+    """Wraps a tree of explicit default/override values."""
+
+    def __init__(self, values=None, parent=None):
+        self.values = values or {}
+        self._parent = parent
+
+    @property
+    def is_struct(self):
+        return isinstance(self.values, dict)
+
+    @property
+    def is_array(self):
+        return False
+
+    @property
+    def is_basic_type(self):
+        return not isinstance(self.values, dict)
+
+    @property
+    def pass_able(self):
+        return False
+
+    @property
+    def parent_source(self):
+        return self._parent
+
+    @property
+    def array_dimensions(self):
+        return []
+
+    def enter_struct(self, field_name, type_hint=None):
+        if isinstance(self.values, dict) and field_name in self.values:
+            val = self.values[field_name]
+            return ValuePointer(val, parent=self)
+        return None
+
+    def enter_array(self, dest=None):
+        return None
+
+    def get_value(self):
+        if not isinstance(self.values, dict):
+            return self.values
+        return None

--- a/ductape/conv/pointers/warning_null_pointer.py
+++ b/ductape/conv/pointers/warning_null_pointer.py
@@ -1,0 +1,41 @@
+"""Null-safe fallback with diagnostics."""
+
+
+class WarningNullPointer:
+    """Null-safe catch-all fallback that emits diagnostics."""
+
+    def __init__(self, type_name="", field_name=""):
+        self.type_name = type_name
+        self.field_name = field_name
+        self.warnings = []
+
+    @property
+    def is_struct(self):
+        return False
+
+    @property
+    def is_array(self):
+        return False
+
+    @property
+    def is_basic_type(self):
+        return False
+
+    @property
+    def pass_able(self):
+        return False
+
+    @property
+    def parent_source(self):
+        return None
+
+    @property
+    def array_dimensions(self):
+        return []
+
+    def enter_struct(self, field_name, type_hint=None):
+        self.warnings.append(f"Missing source for field '{field_name}' in {self.type_name}")
+        return WarningNullPointer(self.type_name, field_name)
+
+    def enter_array(self, dest=None):
+        return WarningNullPointer(self.type_name, self.field_name)

--- a/ductape/conv/preprocessor.py
+++ b/ductape/conv/preprocessor.py
@@ -1,0 +1,87 @@
+"""Built-in C preprocessor: strips comments, captures #defines."""
+
+import re
+
+
+class Preprocessor:
+    """Strip comments, capture #defines, handle multiline macros."""
+
+    def __init__(self):
+        self.defines = {}
+
+    def process(self, source_text):
+        """Process source text: strip comments, capture defines, return clean text."""
+        text = self._strip_comments(source_text)
+        lines = text.split('\n')
+        clean_lines = []
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            # Handle multiline macros (backslash continuation)
+            while line.rstrip().endswith('\\') and i + 1 < len(lines):
+                line = line.rstrip()[:-1] + ' ' + lines[i + 1].strip()
+                i += 1
+            stripped = line.strip()
+            if stripped.startswith('#define'):
+                self._capture_define(stripped)
+                clean_lines.append('')  # preserve line numbering
+            elif stripped.startswith('#'):
+                clean_lines.append('')  # skip other preprocessor directives
+            else:
+                clean_lines.append(line)
+            i += 1
+        return '\n'.join(clean_lines)
+
+    def _strip_comments(self, text):
+        """Remove both // and /* */ comments."""
+        result = []
+        i = 0
+        in_string = False
+        string_char = None
+        while i < len(text):
+            if in_string:
+                if text[i] == '\\' and i + 1 < len(text):
+                    result.append(text[i:i+2])
+                    i += 2
+                    continue
+                if text[i] == string_char:
+                    in_string = False
+                result.append(text[i])
+                i += 1
+            elif text[i] in ('"', "'"):
+                in_string = True
+                string_char = text[i]
+                result.append(text[i])
+                i += 1
+            elif text[i:i+2] == '//':
+                # Line comment - skip to end of line
+                while i < len(text) and text[i] != '\n':
+                    i += 1
+                result.append('\n')  # preserve newline
+                if i < len(text):
+                    i += 1  # skip the newline
+            elif text[i:i+2] == '/*':
+                # Block comment
+                i += 2
+                while i < len(text) - 1 and text[i:i+2] != '*/':
+                    if text[i] == '\n':
+                        result.append('\n')  # preserve line numbering
+                    i += 1
+                if i < len(text) - 1:
+                    i += 2  # skip */
+            else:
+                result.append(text[i])
+                i += 1
+        return ''.join(result)
+
+    def _capture_define(self, line):
+        """Parse a #define line and store name->value."""
+        # Match: #define NAME VALUE
+        m = re.match(r'#define\s+(\w+)\s*(.*)', line)
+        if m:
+            name = m.group(1)
+            value = m.group(2).strip()
+            if value:
+                self.defines[name] = value
+            else:
+                self.defines[name] = ''

--- a/ductape/conv/source_container.py
+++ b/ductape/conv/source_container.py
@@ -1,0 +1,34 @@
+"""Multi-source pointer manager for tree-walking."""
+
+
+class SourceContainer:
+    """Manages an ordered, priority-ranked list of pointers for one destination struct node."""
+
+    def __init__(self, pointers=None):
+        self.pointers = pointers or []
+        self.used = set()
+        self.child_used = set()
+
+    def add_pointer(self, pointer, priority=None):
+        if priority is not None:
+            self.pointers.insert(priority, pointer)
+        else:
+            self.pointers.append(pointer)
+
+    def enter_struct(self, field_name, type_hint=None):
+        """Try each pointer in priority order."""
+        for i, ptr in enumerate(self.pointers):
+            result = ptr.enter_struct(field_name, type_hint)
+            if result is not None:
+                self.used.add(i)
+                return result
+        return None
+
+    def get_best_source(self, field_name, type_hint=None):
+        """Get the highest-priority source that has this field."""
+        for i, ptr in enumerate(self.pointers):
+            result = ptr.enter_struct(field_name, type_hint)
+            if result is not None:
+                self.used.add(i)
+                return ptr, result
+        return None, None

--- a/ductape/conv/tokenizer.py
+++ b/ductape/conv/tokenizer.py
@@ -1,0 +1,158 @@
+"""Lexer: classifies text into typed tokens."""
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+
+class TokenType(Enum):
+    Symbol = auto()
+    Integer = auto()
+    Float = auto()
+    String = auto()
+    Special = auto()
+    Operator = auto()
+    EOF = auto()
+
+
+@dataclass
+class Token:
+    type: TokenType
+    value: str
+    line: int = 0
+
+    def __repr__(self):
+        return f"Token({self.type.name}, {self.value!r})"
+
+
+SPECIAL_CHARS = set('{}[];*(),:')
+OPERATOR_CHARS = set('+-/^')  # * is in Special
+
+
+class Tokenizer:
+    """Tokenize preprocessed C source text."""
+
+    def __init__(self, text):
+        self.text = text
+        self.pos = 0
+        self.line = 1
+        self.tokens = []
+        self._tokenize()
+        self._index = 0
+
+    def _tokenize(self):
+        while self.pos < len(self.text):
+            ch = self.text[self.pos]
+
+            if ch == '\n':
+                self.line += 1
+                self.pos += 1
+                continue
+            if ch.isspace():
+                self.pos += 1
+                continue
+
+            # String literal
+            if ch in ('"', "'"):
+                self._read_string(ch)
+                continue
+
+            # Number
+            if ch.isdigit() or (ch == '.' and self.pos + 1 < len(self.text) and self.text[self.pos + 1].isdigit()):
+                self._read_number()
+                continue
+
+            # Symbol/keyword
+            if ch.isalpha() or ch == '_':
+                self._read_symbol()
+                continue
+
+            # Special characters
+            if ch in SPECIAL_CHARS:
+                self.tokens.append(Token(TokenType.Special, ch, self.line))
+                self.pos += 1
+                continue
+
+            # Operators
+            if ch in OPERATOR_CHARS:
+                self.tokens.append(Token(TokenType.Operator, ch, self.line))
+                self.pos += 1
+                continue
+
+            # Assignment
+            if ch == '=':
+                self.tokens.append(Token(TokenType.Special, '=', self.line))
+                self.pos += 1
+                continue
+
+            # Skip unknown characters
+            self.pos += 1
+
+        self.tokens.append(Token(TokenType.EOF, '', self.line))
+
+    def _read_string(self, quote):
+        start = self.pos
+        self.pos += 1  # skip opening quote
+        while self.pos < len(self.text) and self.text[self.pos] != quote:
+            if self.text[self.pos] == '\\':
+                self.pos += 1  # skip escape
+            if self.text[self.pos] == '\n':
+                self.line += 1
+            self.pos += 1
+        self.pos += 1  # skip closing quote
+        self.tokens.append(Token(TokenType.String, self.text[start:self.pos], self.line))
+
+    def _read_number(self):
+        start = self.pos
+        is_float = False
+        # Handle hex
+        if self.text[self.pos] == '0' and self.pos + 1 < len(self.text) and self.text[self.pos + 1] in 'xX':
+            self.pos += 2
+            while self.pos < len(self.text) and self.text[self.pos] in '0123456789abcdefABCDEF':
+                self.pos += 1
+            self.tokens.append(Token(TokenType.Integer, self.text[start:self.pos], self.line))
+            return
+
+        while self.pos < len(self.text) and (self.text[self.pos].isdigit() or self.text[self.pos] == '.'):
+            if self.text[self.pos] == '.':
+                is_float = True
+            self.pos += 1
+        # Handle suffix like U, L, UL, etc
+        while self.pos < len(self.text) and self.text[self.pos] in 'uUlLfF':
+            self.pos += 1
+
+        tok_type = TokenType.Float if is_float else TokenType.Integer
+        self.tokens.append(Token(tok_type, self.text[start:self.pos], self.line))
+
+    def _read_symbol(self):
+        start = self.pos
+        while self.pos < len(self.text) and (self.text[self.pos].isalnum() or self.text[self.pos] == '_'):
+            self.pos += 1
+        self.tokens.append(Token(TokenType.Symbol, self.text[start:self.pos], self.line))
+
+    def peek(self):
+        if self._index < len(self.tokens):
+            return self.tokens[self._index]
+        return Token(TokenType.EOF, '', self.line)
+
+    def next(self):
+        tok = self.peek()
+        self._index += 1
+        return tok
+
+    def expect(self, tok_type, value=None):
+        tok = self.next()
+        if tok.type != tok_type:
+            raise SyntaxError(f"Expected {tok_type}, got {tok} at line {tok.line}")
+        if value is not None and tok.value != value:
+            raise SyntaxError(f"Expected '{value}', got '{tok.value}' at line {tok.line}")
+        return tok
+
+    def match(self, tok_type, value=None):
+        tok = self.peek()
+        if tok.type == tok_type and (value is None or tok.value == value):
+            self._index += 1
+            return tok
+        return None
+
+    def at_end(self):
+        return self.peek().type == TokenType.EOF

--- a/ductape/conv/type_registry.py
+++ b/ductape/conv/type_registry.py
@@ -1,0 +1,101 @@
+"""Registry + orchestrator: drives generation steps."""
+
+from ductape.conv.data_type import DataType
+from ductape.conv.interface_version import InterfaceVersion
+
+
+class TypeRegistry:
+    """Collects all types from all versions and builds generics."""
+
+    def __init__(self, config):
+        self.config = config
+        self.data_types = {}  # type_name -> DataType
+        self.interface_versions = []  # list of InterfaceVersion
+        self.semantic_warnings = []
+
+    def load_all(self):
+        """Parse all header sources and register types."""
+        base_dir = self.config['_config_dir']
+        version_macros = {
+            name: cfg['version_macro']
+            for name, cfg in self.config['types'].items()
+        }
+        additional_includes = self.config.get('additional_includes', [])
+
+        # Initialize DataType objects
+        for type_name, type_cfg in self.config['types'].items():
+            dt = DataType(
+                name=type_name,
+                version_macro=type_cfg['version_macro'],
+                defaults=type_cfg.get('defaults', {}),
+                renames=type_cfg.get('renames', {}),
+                field_warnings=type_cfg.get('field_warnings', {}),
+                generate_reverse=type_cfg.get('generate_reverse', False),
+            )
+            self.data_types[type_name] = dt
+
+        # Parse each header source
+        for source in self.config['header_sources']:
+            iv = InterfaceVersion(
+                base_dir=base_dir,
+                path=source['path'],
+                version_tag=source['version_tag'],
+                additional_includes=additional_includes,
+            )
+            iv.parse(version_macros)
+            self.interface_versions.append(iv)
+
+            # Register types found
+            for type_name, dt in self.data_types.items():
+                if type_name in iv.container.types and type_name in iv.version_numbers:
+                    ver_num = iv.version_numbers[type_name]
+                    dt.add_version(ver_num, iv.container.types[type_name])
+
+        # Build generics
+        sentinel = self.config['project'].get('generic_version_sentinel', 9999)
+        for dt in self.data_types.values():
+            dt.build_generic(sentinel)
+
+        # Run semantic checks
+        self._check_field_compatibility()
+
+    def _check_field_compatibility(self):
+        """Check field type compatibility across versions (FR-20)."""
+        for dt in self.data_types.values():
+            if dt.generic is None:
+                continue
+            for member in dt.generic.ctype.members:
+                field_types = {}
+                for ver_num, dtv in dt.versions.items():
+                    # Find this field in the version (with rename awareness)
+                    src_name = self._find_source_field_name(dt, member.name, dtv)
+                    if src_name is None:
+                        continue
+                    for src_member in dtv.ctype.members:
+                        if src_member.name == src_name:
+                            field_types[ver_num] = src_member.type_name
+                            break
+
+                # Check consistency
+                unique_types = set(field_types.values())
+                if len(unique_types) > 1:
+                    self.semantic_warnings.append({
+                        'type': dt.name,
+                        'field': member.name,
+                        'severity': 2,
+                        'message': f"Field '{member.name}' has different types across versions: {field_types}",
+                    })
+
+    def _find_source_field_name(self, dt, generic_name, dtv):
+        """Find the source field name for a generic field, considering renames."""
+        # Check if there's a reverse rename (new_name -> old_name)
+        reverse_renames = {v: k for k, v in dt.renames.items()}
+        old_name = reverse_renames.get(generic_name, generic_name)
+
+        # Check if version has the canonical name
+        for m in dtv.ctype.members:
+            if m.name == generic_name:
+                return generic_name
+            if m.name == old_name:
+                return old_name
+        return None

--- a/ductape/conv/typecontainer.py
+++ b/ductape/conv/typecontainer.py
@@ -1,0 +1,78 @@
+"""AST-like model: types, defines, namespaces."""
+
+from dataclasses import dataclass, field
+from collections import OrderedDict
+from typing import Optional
+
+
+@dataclass
+class CType:
+    name: str
+    is_struct: bool = False
+    is_enum: bool = False
+    is_basic_type: bool = False
+    is_array: bool = False
+    dimensions: list = field(default_factory=list)
+    members: list = field(default_factory=list)  # list of CTypeMember
+    enum_values: list = field(default_factory=list)  # list of (name, value)
+    aliased_type: Optional[str] = None
+    bitfield_width: Optional[int] = None
+
+    def member_count(self):
+        return len(self.members)
+
+
+@dataclass
+class CTypeMember:
+    name: str
+    type_name: str
+    is_array: bool = False
+    dimensions: list = field(default_factory=list)
+    is_struct: bool = False
+    is_enum: bool = False
+    is_basic_type: bool = False
+    bitfield_width: Optional[int] = None
+
+
+class TypeContainer:
+    """Container for parsed C types, defines, and namespaces."""
+
+    # Standard C/platform basic types
+    BASIC_TYPES = [
+        'void', 'char', 'short', 'int', 'long', 'float', 'double',
+        'unsigned', 'signed',
+        'uint8', 'sint8', 'uint16', 'sint16', 'uint32', 'sint32',
+        'uint64', 'sint64', 'float32', 'float64', 'boolean',
+        'uint8_t', 'int8_t', 'uint16_t', 'int16_t', 'uint32_t', 'int32_t',
+        'uint64_t', 'int64_t', 'size_t', 'bool',
+    ]
+
+    def __init__(self):
+        self.basictypes = OrderedDict()
+        self.types = OrderedDict()
+        self.defines = OrderedDict()
+        self.namespaces = OrderedDict()
+        self._init_basic_types()
+
+    def _init_basic_types(self):
+        for t in self.BASIC_TYPES:
+            self.basictypes[t] = CType(name=t, is_basic_type=True)
+
+    def add_type(self, name, ctype):
+        self.types[name] = ctype
+
+    def add_define(self, name, value):
+        self.defines[name] = value
+
+    def get_type(self, name):
+        if name in self.types:
+            return self.types[name]
+        if name in self.basictypes:
+            return self.basictypes[name]
+        return None
+
+    def is_known_type(self, name):
+        return name in self.types or name in self.basictypes
+
+    def add_namespace(self, name, container):
+        self.namespaces[name] = container

--- a/ductape/conv/value_container.py
+++ b/ductape/conv/value_container.py
@@ -1,0 +1,27 @@
+"""Default / override value holder."""
+
+
+class ValueContainer:
+    """Holds a tree of default/override values parsed from config."""
+
+    def __init__(self, defaults_dict=None):
+        self.tree = {}
+        if defaults_dict:
+            self._build_tree(defaults_dict)
+
+    def _build_tree(self, flat_dict):
+        """Convert dot-separated keys to nested dict."""
+        for key, value in flat_dict.items():
+            parts = key.split('.')
+            node = self.tree
+            for part in parts[:-1]:
+                if part not in node:
+                    node[part] = {}
+                node = node[part]
+            node[parts[-1]] = value
+
+    def get(self, field_name):
+        return self.tree.get(field_name)
+
+    def has(self, field_name):
+        return field_name in self.tree

--- a/ductape/warnings.py
+++ b/ductape/warnings.py
@@ -1,0 +1,47 @@
+"""Centralised diagnostic collector (WarningModule)."""
+
+import sys
+
+
+class WarningModule:
+    """Collects and displays warnings with severity levels."""
+
+    SEVERITY_NAMES = {0: "INFO", 1: "WARNING", 2: "ERROR"}
+    SEVERITY_COLORS = {0: "\033[34m", 1: "\033[33m", 2: "\033[31m"}
+    RESET = "\033[0m"
+
+    def __init__(self, min_severity=1, use_color=True):
+        self.min_severity = min_severity
+        self.use_color = use_color
+        self.warnings = []
+
+    def add(self, message, severity=1, context=""):
+        self.warnings.append({
+            'message': message,
+            'severity': severity,
+            'context': context,
+        })
+
+    def display(self, file=None):
+        file = file or sys.stderr
+        for w in self.warnings:
+            if w['severity'] >= self.min_severity:
+                self._print_warning(w, file)
+
+    def _print_warning(self, warning, file):
+        sev = warning['severity']
+        name = self.SEVERITY_NAMES.get(sev, "UNKNOWN")
+        msg = warning['message']
+        ctx = f" [{warning['context']}]" if warning['context'] else ""
+
+        if self.use_color:
+            color = self.SEVERITY_COLORS.get(sev, "")
+            print(f"{color}[{name}]{self.RESET}{ctx} {msg}", file=file)
+        else:
+            print(f"[{name}]{ctx} {msg}", file=file)
+
+    def has_errors(self):
+        return any(w['severity'] >= 2 for w in self.warnings)
+
+    def count(self, min_severity=0):
+        return sum(1 for w in self.warnings if w['severity'] >= min_severity)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ductape"
+version = "0.1.0"
+description = "Universal Schema Adapter Generator"
+requires-python = ">=3.10"
+dependencies = ["pyyaml"]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[project.scripts]
+ductape = "ductape.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["ductape*"]

--- a/runtime_reference/adapter_base.h
+++ b/runtime_reference/adapter_base.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+class IVersionInfo {
+public:
+  virtual ~IVersionInfo() = default;
+  virtual uint32_t GetVersion() const = 0;
+};
+
+class AdapterConverterBase {
+public:
+  virtual ~AdapterConverterBase() = default;
+  virtual const char* GetTypeName() const = 0;
+  virtual long ConvertData(
+      uint32_t src_type_tag, unsigned long src_size,
+      const IVersionInfo& src_version,
+      uint32_t dst_type_tag, unsigned long dst_size,
+      const IVersionInfo* dst_version,
+      void* dst_data,
+      void** out_data, unsigned long& out_size) = 0;
+  virtual long GetDefaultValue(
+      uint32_t type_tag, unsigned long size,
+      const IVersionInfo& version,
+      void** default_data, unsigned long& default_size) = 0;
+  virtual bool AreVersionsCompatible(
+      uint32_t src_type_tag, unsigned long src_size,
+      const IVersionInfo& src_version,
+      uint32_t dst_type_tag, unsigned long dst_size,
+      const IVersionInfo& dst_version) = 0;
+};

--- a/runtime_reference/version_info.h
+++ b/runtime_reference/version_info.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "adapter_base.h"
+
+class SimpleVersionInfo : public IVersionInfo {
+public:
+  explicit SimpleVersionInfo(uint32_t version) : version_(version) {}
+  uint32_t GetVersion() const override { return version_; }
+private:
+  uint32_t version_;
+};

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,101 @@
+"""Tests for config validation."""
+
+import os
+import pytest
+import tempfile
+import yaml
+from ductape.config import load_config, ConfigError
+
+
+def _write_config(data):
+    f = tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False)
+    yaml.dump(data, f)
+    f.close()
+    return f.name
+
+
+def _minimal_config():
+    return {
+        'project': {'name': 'test'},
+        'header_sources': [{'path': 'headers/v1', 'version_tag': 'v1'}],
+        'types': {
+            'Foo_t': {'version_macro': 'FOO_VERSION'}
+        },
+    }
+
+
+def test_valid_config():
+    path = _write_config(_minimal_config())
+    cfg = load_config(path)
+    assert cfg['project']['name'] == 'test'
+    os.unlink(path)
+
+
+def test_missing_project():
+    data = _minimal_config()
+    del data['project']
+    path = _write_config(data)
+    with pytest.raises(ConfigError, match="project"):
+        load_config(path)
+    os.unlink(path)
+
+
+def test_missing_header_sources():
+    data = _minimal_config()
+    del data['header_sources']
+    path = _write_config(data)
+    with pytest.raises(ConfigError, match="header_sources"):
+        load_config(path)
+    os.unlink(path)
+
+
+def test_missing_types():
+    data = _minimal_config()
+    del data['types']
+    path = _write_config(data)
+    with pytest.raises(ConfigError, match="types"):
+        load_config(path)
+    os.unlink(path)
+
+
+def test_empty_types():
+    data = _minimal_config()
+    data['types'] = {}
+    path = _write_config(data)
+    with pytest.raises(ConfigError, match="empty"):
+        load_config(path)
+    os.unlink(path)
+
+
+def test_missing_version_macro():
+    data = _minimal_config()
+    data['types']['Foo_t'] = {'defaults': {}}
+    path = _write_config(data)
+    with pytest.raises(ConfigError, match="version_macro"):
+        load_config(path)
+    os.unlink(path)
+
+
+def test_defaults_set():
+    path = _write_config(_minimal_config())
+    cfg = load_config(path)
+    assert cfg['project']['generic_version_sentinel'] == 9999
+    assert cfg['types']['Foo_t']['defaults'] == {}
+    assert cfg['types']['Foo_t']['renames'] == {}
+    os.unlink(path)
+
+
+def test_file_not_found():
+    with pytest.raises(ConfigError, match="not found"):
+        load_config("/nonexistent/config.yaml")
+
+
+def test_load_reference_config():
+    """Load the actual reference project config."""
+    config_path = os.path.join(os.path.dirname(__file__), "..",
+                               "variants/reference_project/config.yaml")
+    cfg = load_config(config_path)
+    assert cfg['project']['name'] == 'reference_project'
+    assert 'TelemetryData_t' in cfg['types']
+    assert 'CommandMessage_t' in cfg['types']
+    assert 'SystemStatus_t' in cfg['types']

--- a/tests/test_converter_generation.py
+++ b/tests/test_converter_generation.py
@@ -1,0 +1,135 @@
+"""Tests for converter generation."""
+
+import os
+import tempfile
+import pytest
+from ductape.config import load_config
+from ductape.conv.type_registry import TypeRegistry
+from ductape.conv.converter import Converter
+from ductape.conv.code_writer import CodeWriter
+from ductape.codegen import run_generate
+
+
+@pytest.fixture
+def registry():
+    config_path = os.path.join(os.path.dirname(__file__), "..",
+                               "variants/reference_project/config.yaml")
+    config = load_config(config_path)
+    reg = TypeRegistry(config)
+    reg.load_all()
+    return reg, config
+
+
+def test_generate_creates_data_type_headers(registry):
+    reg, config = registry
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_generate(os.path.join(os.path.dirname(__file__), "..",
+                     "variants/reference_project/config.yaml"), tmpdir)
+        assert os.path.isfile(os.path.join(tmpdir, "data_types", "TelemetryData_t.h"))
+        assert os.path.isfile(os.path.join(tmpdir, "data_types", "CommandMessage_t.h"))
+        assert os.path.isfile(os.path.join(tmpdir, "data_types", "SystemStatus_t.h"))
+
+
+def test_generate_creates_converter_files(registry):
+    reg, config = registry
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_generate(os.path.join(os.path.dirname(__file__), "..",
+                     "variants/reference_project/config.yaml"), tmpdir)
+        assert os.path.isfile(os.path.join(tmpdir, "converters", "generated", "Converter_TelemetryData_t.cpp"))
+        assert os.path.isfile(os.path.join(tmpdir, "converters", "generated", "Converter_TelemetryData_t.h"))
+
+
+def test_generate_creates_factory(registry):
+    reg, config = registry
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_generate(os.path.join(os.path.dirname(__file__), "..",
+                     "variants/reference_project/config.yaml"), tmpdir)
+        factory_path = os.path.join(tmpdir, "converters", "generated", "converters.cpp")
+        assert os.path.isfile(factory_path)
+        with open(factory_path) as f:
+            content = f.read()
+        assert "GetGeneratedAdapters" in content
+
+
+def test_converter_forward_body():
+    """Test that forward converter body is generated."""
+    config_path = os.path.join(os.path.dirname(__file__), "..",
+                               "variants/reference_project/config.yaml")
+    config = load_config(config_path)
+    reg = TypeRegistry(config)
+    reg.load_all()
+
+    dt = reg.data_types["TelemetryData_t"]
+    conv = Converter(dt, config)
+    w = CodeWriter()
+    conv.generate_forward_body(dt.versions[1], w)
+    content = w.get_content()
+    assert "memset" in content
+    assert "dest.timestamp" in content
+
+
+def test_converter_structural_identity():
+    """Test structural identity check."""
+    config_path = os.path.join(os.path.dirname(__file__), "..",
+                               "variants/reference_project/config.yaml")
+    config = load_config(config_path)
+    reg = TypeRegistry(config)
+    reg.load_all()
+
+    dt = reg.data_types["TelemetryData_t"]
+    conv = Converter(dt, config)
+    # V1 and generic should NOT be identical
+    assert not conv.are_structurally_identical(dt.versions[1], dt.generic)
+
+
+def test_converter_rename_handling():
+    """Test that renames are handled in conversion."""
+    config_path = os.path.join(os.path.dirname(__file__), "..",
+                               "variants/reference_project/config.yaml")
+    config = load_config(config_path)
+    reg = TypeRegistry(config)
+    reg.load_all()
+
+    dt = reg.data_types["TelemetryData_t"]
+    conv = Converter(dt, config)
+    w = CodeWriter()
+    conv.generate_forward_body(dt.versions[1], w)
+    content = w.get_content()
+    # V1 has "speed", generic has "ground_speed" (renamed)
+    assert "source.speed" in content
+    assert "dest.ground_speed" in content
+
+
+def test_converter_array_min_copy():
+    """Test array min-dimension copy generation."""
+    config_path = os.path.join(os.path.dirname(__file__), "..",
+                               "variants/reference_project/config.yaml")
+    config = load_config(config_path)
+    reg = TypeRegistry(config)
+    reg.load_all()
+
+    dt = reg.data_types["TelemetryData_t"]
+    conv = Converter(dt, config)
+    w = CodeWriter()
+    # V1 has payload[32], generic has payload[64]
+    conv.generate_forward_body(dt.versions[1], w)
+    content = w.get_content()
+    assert "for (int i = 0; i < " in content
+    assert "payload[i]" in content
+
+
+def test_data_type_header_content():
+    """Test generated header has correct structure."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(os.path.dirname(__file__), "..",
+                                   "variants/reference_project/config.yaml")
+        run_generate(config_path, tmpdir)
+        header_path = os.path.join(tmpdir, "data_types", "TelemetryData_t.h")
+        with open(header_path) as f:
+            content = f.read()
+        assert "#pragma once" in content
+        assert "namespace TelemetryData_t_V_1" in content
+        assert "namespace TelemetryData_t_V_2" in content
+        assert "namespace TelemetryData_t_V_3" in content
+        assert "namespace TelemetryData_t_V_Gen" in content
+        assert "platform_types.h" in content

--- a/tests/test_expression_eval.py
+++ b/tests/test_expression_eval.py
@@ -1,0 +1,59 @@
+"""Tests for expression evaluator."""
+
+from ductape.conv.expression_eval import ExpressionEvaluator
+
+
+def test_simple_integer():
+    ev = ExpressionEvaluator()
+    assert ev.evaluate("42") == 42
+
+
+def test_addition():
+    ev = ExpressionEvaluator()
+    assert ev.evaluate("10 + 20") == 30
+
+
+def test_complex_expression():
+    ev = ExpressionEvaluator()
+    assert ev.evaluate("(32 + 4) * 2") == 72
+
+
+def test_symbol_substitution():
+    ev = ExpressionEvaluator({"BASE_SIZE": 32})
+    assert ev.evaluate("BASE_SIZE + 4") == 36
+
+
+def test_chained_symbols():
+    ev = ExpressionEvaluator({"BASE": 32, "BUF": "(BASE + 4)"})
+    assert ev.evaluate("BUF / 2") == 18
+
+
+def test_bitwise_operations():
+    ev = ExpressionEvaluator()
+    assert ev.evaluate("0xFF & 0x0F") == 15
+
+
+def test_shift_operations():
+    ev = ExpressionEvaluator()
+    assert ev.evaluate("1 << 8") == 256
+
+
+def test_modulo():
+    ev = ExpressionEvaluator()
+    assert ev.evaluate("17 % 5") == 2
+
+
+def test_unknown_symbol_returns_none():
+    ev = ExpressionEvaluator()
+    assert ev.evaluate("UNKNOWN_VAR") is None
+
+
+def test_empty_returns_none():
+    ev = ExpressionEvaluator()
+    assert ev.evaluate("") is None
+    assert ev.evaluate(None) is None
+
+
+def test_parentheses():
+    ev = ExpressionEvaluator()
+    assert ev.evaluate("(2 + 3) * (4 - 1)") == 15

--- a/tests/test_golden_files.py
+++ b/tests/test_golden_files.py
@@ -1,0 +1,53 @@
+"""Regression: compare output vs expected_output."""
+
+import os
+import tempfile
+import filecmp
+from ductape.codegen import run_generate
+
+
+def test_golden_files_match():
+    """Verify generated output matches expected golden files."""
+    config_path = os.path.join(os.path.dirname(__file__), "..",
+                               "variants/reference_project/config.yaml")
+    expected_dir = os.path.join(os.path.dirname(__file__), "..",
+                                "variants/reference_project/expected_output")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_generate(config_path, tmpdir)
+
+        differences = []
+        for dirpath, dirnames, filenames in os.walk(expected_dir):
+            for fname in filenames:
+                expected_file = os.path.join(dirpath, fname)
+                rel_path = os.path.relpath(expected_file, expected_dir)
+                generated_file = os.path.join(tmpdir, rel_path)
+
+                if not os.path.isfile(generated_file):
+                    differences.append(f"Missing: {rel_path}")
+                elif not filecmp.cmp(expected_file, generated_file, shallow=False):
+                    differences.append(f"Differs: {rel_path}")
+
+        assert differences == [], f"Golden file differences: {differences}"
+
+
+def test_all_expected_files_exist():
+    """Verify that all expected output files are present."""
+    expected_dir = os.path.join(os.path.dirname(__file__), "..",
+                                "variants/reference_project/expected_output")
+    expected_files = [
+        "data_types/TelemetryData_t.h",
+        "data_types/CommandMessage_t.h",
+        "data_types/SystemStatus_t.h",
+        "data_types/platform_types.h",
+        "converters/generated/Converter_TelemetryData_t.h",
+        "converters/generated/Converter_TelemetryData_t.cpp",
+        "converters/generated/Converter_CommandMessage_t.h",
+        "converters/generated/Converter_CommandMessage_t.cpp",
+        "converters/generated/Converter_SystemStatus_t.h",
+        "converters/generated/Converter_SystemStatus_t.cpp",
+        "converters/generated/converters.cpp",
+        "field_provenance.json",
+    ]
+    for f in expected_files:
+        assert os.path.isfile(os.path.join(expected_dir, f)), f"Missing: {f}"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,195 @@
+"""Tests for C parser."""
+
+import os
+from ductape.conv.parser import Parser
+
+
+def test_simple_struct():
+    src = """
+    typedef struct {
+        uint32 x;
+        uint32 y;
+    } Point_t;
+    """
+    p = Parser()
+    tc = p.parse(src)
+    assert "Point_t" in tc.types
+    assert tc.types["Point_t"].is_struct
+    assert tc.types["Point_t"].member_count() == 2
+
+
+def test_struct_with_array():
+    src = """
+    #define SIZE 10
+    typedef struct {
+        uint8 data[SIZE];
+        uint32 count;
+    } Buffer_t;
+    """
+    p = Parser()
+    tc = p.parse(src)
+    assert "Buffer_t" in tc.types
+    buf = tc.types["Buffer_t"]
+    assert buf.members[0].is_array
+    assert buf.members[0].dimensions == [10]
+
+
+def test_enum():
+    src = """
+    typedef enum {
+        STATE_IDLE = 0,
+        STATE_RUNNING,
+        STATE_ERROR = 5,
+        STATE_DONE
+    } State_t;
+    """
+    p = Parser()
+    tc = p.parse(src)
+    assert "State_t" in tc.types
+    assert tc.types["State_t"].is_enum
+    vals = dict(tc.types["State_t"].enum_values)
+    assert vals["STATE_IDLE"] == 0
+    assert vals["STATE_RUNNING"] == 1
+    assert vals["STATE_ERROR"] == 5
+    assert vals["STATE_DONE"] == 6
+
+
+def test_typedef_alias():
+    src = "typedef uint32 MyUint;"
+    p = Parser()
+    tc = p.parse(src)
+    assert "MyUint" in tc.types
+    assert tc.types["MyUint"].aliased_type == "uint32"
+
+
+def test_defines_captured():
+    src = """
+    #define VERSION 3
+    #define BUF_SIZE 64
+    """
+    p = Parser()
+    tc = p.parse(src)
+    assert tc.defines["VERSION"] == 3
+    assert tc.defines["BUF_SIZE"] == 64
+
+
+def test_nested_struct():
+    src = """
+    typedef struct {
+        float32 voltage;
+        float32 current;
+    } BatteryInfo_t;
+
+    typedef struct {
+        uint32 timestamp;
+        BatteryInfo_t battery;
+    } TelemetryData_t;
+    """
+    p = Parser()
+    tc = p.parse(src)
+    assert "BatteryInfo_t" in tc.types
+    assert "TelemetryData_t" in tc.types
+    td = tc.types["TelemetryData_t"]
+    assert td.member_count() == 2
+    assert td.members[1].type_name == "BatteryInfo_t"
+
+
+def test_comments_stripped():
+    src = """
+    // This is a comment
+    typedef struct {
+        uint32 x; /* inline comment */
+    } Foo_t;
+    """
+    p = Parser()
+    tc = p.parse(src)
+    assert "Foo_t" in tc.types
+
+
+def test_cpp_style_struct():
+    src = """
+    struct MyStruct {
+        uint32 value;
+        float32 ratio;
+    };
+    """
+    p = Parser()
+    tc = p.parse(src)
+    assert "MyStruct" in tc.types
+    assert tc.types["MyStruct"].is_struct
+    assert tc.types["MyStruct"].member_count() == 2
+
+
+def test_forward_declaration():
+    src = "struct ForwardDecl;"
+    p = Parser()
+    tc = p.parse(src)
+    # Should not crash, forward decl not added as full type
+    assert "ForwardDecl" not in tc.types
+
+
+def test_tagged_typedef():
+    src = """
+    typedef struct TagName {
+        uint32 a;
+        uint32 b;
+    } AliasName;
+    """
+    p = Parser()
+    tc = p.parse(src)
+    assert "AliasName" in tc.types
+    assert tc.types["AliasName"].member_count() == 2
+
+
+def test_parse_v1_header():
+    header_path = os.path.join(os.path.dirname(__file__), "..",
+                               "variants/reference_project/headers/v1/telemetry_types.h")
+    with open(header_path) as f:
+        src = f.read()
+    p = Parser()
+    tc = p.parse(src)
+    assert "TelemetryData_t" in tc.types
+    assert "CommandMessage_t" in tc.types
+    assert "SystemStatus_t" in tc.types
+    # V1 TelemetryData_t: timestamp, speed, altitude, heading, latitude, longitude, status, payload = 8
+    assert tc.types["TelemetryData_t"].member_count() == 8
+
+
+def test_parse_v2_header():
+    header_path = os.path.join(os.path.dirname(__file__), "..",
+                               "variants/reference_project/headers/v2/telemetry_types.h")
+    with open(header_path) as f:
+        src = f.read()
+    p = Parser()
+    tc = p.parse(src)
+    assert "TelemetryData_t" in tc.types
+    # V2: timestamp, speed, altitude, heading, latitude, longitude, vertical_speed,
+    #     status, signal_quality, payload, battery = 11
+    assert tc.types["TelemetryData_t"].member_count() == 11
+
+
+def test_parse_v3_header():
+    header_path = os.path.join(os.path.dirname(__file__), "..",
+                               "variants/reference_project/headers/v3/telemetry_types.h")
+    with open(header_path) as f:
+        src = f.read()
+    p = Parser()
+    tc = p.parse(src)
+    assert "TelemetryData_t" in tc.types
+    # V3: timestamp, ground_speed, altitude_msl, heading, latitude, longitude,
+    #     vertical_speed, airspeed, op_status, signal_quality, satellite_count,
+    #     mission_phase, sequence_number, payload, battery = 15
+    assert tc.types["TelemetryData_t"].member_count() == 15
+
+
+def test_bitfield():
+    src = """
+    typedef struct {
+        uint32 flags : 4;
+        uint32 reserved : 28;
+    } BitStruct_t;
+    """
+    p = Parser()
+    tc = p.parse(src)
+    assert "BitStruct_t" in tc.types
+    assert tc.types["BitStruct_t"].members[0].bitfield_width == 4

--- a/tests/test_pointer_abstractions.py
+++ b/tests/test_pointer_abstractions.py
@@ -1,0 +1,95 @@
+"""Tests for pointer abstractions."""
+
+import pytest
+from ductape.conv.typecontainer import CType, CTypeMember
+from ductape.conv.pointers.struct_pointer import StructPointer, AmbiguousMemberError
+from ductape.conv.pointers.value_pointer import ValuePointer
+from ductape.conv.pointers.warning_null_pointer import WarningNullPointer
+from ductape.conv.value_container import ValueContainer
+
+
+def _make_struct():
+    return CType(
+        name="TestStruct",
+        is_struct=True,
+        members=[
+            CTypeMember(name="x", type_name="uint32", is_basic_type=True),
+            CTypeMember(name="y", type_name="float32", is_basic_type=True),
+            CTypeMember(name="data", type_name="uint8", is_array=True, dimensions=[32], is_basic_type=True),
+        ],
+    )
+
+
+def test_exact_match():
+    sp = StructPointer(_make_struct(), "Test_V_1")
+    result = sp.enter_struct("x")
+    assert result is not None
+    assert result.ctype.name == "uint32"
+
+
+def test_exact_match_not_found():
+    sp = StructPointer(_make_struct(), "Test_V_1")
+    result = sp.enter_struct("nonexistent")
+    assert result is None
+
+
+def test_fuzzy_match_with_suffix():
+    ct = CType(
+        name="Test",
+        is_struct=True,
+        members=[
+            CTypeMember(name="speed_t", type_name="float32", is_basic_type=True),
+        ],
+    )
+    sp = StructPointer(ct, "Test_V_1")
+    result = sp.enter_struct("speed")
+    assert result is not None
+
+
+def test_ambiguity_error():
+    ct = CType(
+        name="Test",
+        is_struct=True,
+        members=[
+            CTypeMember(name="speed_t", type_name="float32", is_basic_type=True),
+            CTypeMember(name="speed_T", type_name="float32", is_basic_type=True),
+        ],
+    )
+    sp = StructPointer(ct, "Test_V_1")
+    with pytest.raises(AmbiguousMemberError):
+        sp.enter_struct("speed")
+
+
+def test_value_pointer():
+    vp = ValuePointer({"x": "42", "nested": {"a": "1"}})
+    child = vp.enter_struct("x")
+    assert child is not None
+    assert child.get_value() == "42"
+
+    nested = vp.enter_struct("nested")
+    assert nested.is_struct
+    a = nested.enter_struct("a")
+    assert a.get_value() == "1"
+
+
+def test_warning_null_pointer():
+    wnp = WarningNullPointer("Test", "field")
+    result = wnp.enter_struct("x")
+    assert isinstance(result, WarningNullPointer)
+    assert len(wnp.warnings) == 1
+
+
+def test_value_container_tree():
+    vc = ValueContainer({"battery.voltage": "0.0", "battery.current": "0.0", "speed": "0"})
+    assert vc.has("battery")
+    assert vc.has("speed")
+    bat = vc.get("battery")
+    assert bat == {"voltage": "0.0", "current": "0.0"}
+
+
+def test_struct_pointer_array():
+    sp = StructPointer(_make_struct(), "Test_V_1")
+    data = sp.enter_struct("data")
+    assert data is not None
+    assert data.ctype.is_array
+    assert data.ctype.dimensions == [32]

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -1,0 +1,70 @@
+"""Tests for the C preprocessor."""
+
+from ductape.conv.preprocessor import Preprocessor
+
+
+def test_strip_line_comment():
+    pp = Preprocessor()
+    result = pp.process("int x; // comment\nint y;")
+    assert "// comment" not in result
+    assert "int x;" in result
+    assert "int y;" in result
+
+
+def test_strip_block_comment():
+    pp = Preprocessor()
+    result = pp.process("int x; /* block\ncomment */ int y;")
+    assert "/* block" not in result
+    assert "int y;" in result
+
+
+def test_capture_simple_define():
+    pp = Preprocessor()
+    pp.process("#define FOO 42\n")
+    assert pp.defines["FOO"] == "42"
+
+
+def test_capture_define_expression():
+    pp = Preprocessor()
+    pp.process("#define SIZE (32 + 4)\n")
+    assert pp.defines["SIZE"] == "(32 + 4)"
+
+
+def test_multiline_define():
+    pp = Preprocessor()
+    pp.process("#define FOO \\\n  42\n")
+    assert pp.defines["FOO"] == "42"
+
+
+def test_define_no_value():
+    pp = Preprocessor()
+    pp.process("#define GUARD_H\n")
+    assert pp.defines["GUARD_H"] == ""
+
+
+def test_skip_includes_and_pragmas():
+    pp = Preprocessor()
+    result = pp.process('#include "foo.h"\n#pragma once\nint x;')
+    assert '#include' not in result
+    assert '#pragma' not in result
+    assert 'int x;' in result
+
+
+def test_preserves_string_with_slash():
+    pp = Preprocessor()
+    result = pp.process('char* s = "hello // world";')
+    assert '"hello // world"' in result
+
+
+def test_nested_block_comments():
+    pp = Preprocessor()
+    result = pp.process("/* outer /* still comment */ int x;")
+    assert "int x;" in result
+
+
+def test_multiple_defines():
+    pp = Preprocessor()
+    pp.process("#define A 1\n#define B 2\n#define C 3\n")
+    assert pp.defines["A"] == "1"
+    assert pp.defines["B"] == "2"
+    assert pp.defines["C"] == "3"

--- a/tests/test_semantic_conflicts.py
+++ b/tests/test_semantic_conflicts.py
@@ -1,0 +1,95 @@
+"""Tests for semantic conflict detection and field provenance."""
+
+import os
+import json
+import tempfile
+from ductape.config import load_config
+from ductape.conv.type_registry import TypeRegistry
+from ductape.conv.field_provenance import generate_provenance
+from ductape.codegen import run_generate
+from ductape.warnings import WarningModule
+
+
+def _get_registry():
+    config_path = os.path.join(os.path.dirname(__file__), "..",
+                               "variants/reference_project/config.yaml")
+    config = load_config(config_path)
+    reg = TypeRegistry(config)
+    reg.load_all()
+    return reg, config
+
+
+def test_provenance_has_all_types():
+    reg, config = _get_registry()
+    prov = generate_provenance(reg)
+    assert "TelemetryData_t" in prov
+    assert "CommandMessage_t" in prov
+    assert "SystemStatus_t" in prov
+
+
+def test_provenance_version_mappings():
+    reg, config = _get_registry()
+    prov = generate_provenance(reg)
+    telemetry = prov["TelemetryData_t"]
+    # timestamp should be in all 3 versions
+    ts = telemetry["timestamp"]
+    assert "1" in ts["versions"]
+    assert "2" in ts["versions"]
+    assert "3" in ts["versions"]
+    assert ts["type_compatible"] is True
+
+
+def test_provenance_rename_tracking():
+    reg, config = _get_registry()
+    prov = generate_provenance(reg)
+    telemetry = prov["TelemetryData_t"]
+    # ground_speed was "speed" in V1 and V2
+    gs = telemetry["ground_speed"]
+    assert gs["versions"]["1"]["rename_from"] == "speed"
+    assert gs["versions"]["2"]["rename_from"] == "speed"
+    # V3 uses ground_speed directly
+    assert "rename_from" not in gs["versions"]["3"]
+
+
+def test_provenance_defaults_tracked():
+    reg, config = _get_registry()
+    prov = generate_provenance(reg)
+    telemetry = prov["TelemetryData_t"]
+    # signal_quality not in V1, should have default_applied_for
+    sq = telemetry["signal_quality"]
+    assert 1 in sq.get("default_applied_for", [])
+
+
+def test_provenance_field_warnings():
+    reg, config = _get_registry()
+    prov = generate_provenance(reg)
+    telemetry = prov["TelemetryData_t"]
+    # op_status has a field warning
+    ops = telemetry["op_status"]
+    assert len(ops["warnings"]) > 0
+    assert ops["warnings"][0]["severity"] == 1
+
+
+def test_field_provenance_json_generated():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(os.path.dirname(__file__), "..",
+                                   "variants/reference_project/config.yaml")
+        run_generate(config_path, tmpdir)
+        prov_path = os.path.join(tmpdir, "field_provenance.json")
+        assert os.path.isfile(prov_path)
+        with open(prov_path) as f:
+            data = json.load(f)
+        assert "TelemetryData_t" in data
+        assert "CommandMessage_t" in data
+        assert "SystemStatus_t" in data
+
+
+def test_warning_module():
+    wm = WarningModule(min_severity=1, use_color=False)
+    wm.add("info message", severity=0)
+    wm.add("warning message", severity=1)
+    wm.add("error message", severity=2)
+    assert wm.count(0) == 3
+    assert wm.count(1) == 2
+    assert wm.count(2) == 1
+    assert wm.has_errors()

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,82 @@
+"""Tests for tokenizer."""
+
+from ductape.conv.tokenizer import Tokenizer, TokenType
+
+
+def test_symbol():
+    t = Tokenizer("hello")
+    tok = t.next()
+    assert tok.type == TokenType.Symbol
+    assert tok.value == "hello"
+
+
+def test_integer():
+    t = Tokenizer("42")
+    tok = t.next()
+    assert tok.type == TokenType.Integer
+    assert tok.value == "42"
+
+
+def test_hex_integer():
+    t = Tokenizer("0xFF")
+    tok = t.next()
+    assert tok.type == TokenType.Integer
+    assert tok.value == "0xFF"
+
+
+def test_float():
+    t = Tokenizer("3.14")
+    tok = t.next()
+    assert tok.type == TokenType.Float
+    assert tok.value == "3.14"
+
+
+def test_string():
+    t = Tokenizer('"hello world"')
+    tok = t.next()
+    assert tok.type == TokenType.String
+    assert tok.value == '"hello world"'
+
+
+def test_special_chars():
+    t = Tokenizer("{ } ; * [ ]")
+    types = []
+    while not t.at_end():
+        tok = t.next()
+        types.append(tok.value)
+    assert types == ['{', '}', ';', '*', '[', ']']
+
+
+def test_operators():
+    t = Tokenizer("+ - /")
+    types = []
+    while not t.at_end():
+        tok = t.next()
+        assert tok.type == TokenType.Operator
+        types.append(tok.value)
+    assert types == ['+', '-', '/']
+
+
+def test_eof():
+    t = Tokenizer("")
+    tok = t.next()
+    assert tok.type == TokenType.EOF
+
+
+def test_struct_tokens():
+    t = Tokenizer("typedef struct { uint32 x; } Foo_t;")
+    tokens = []
+    while not t.at_end():
+        tokens.append(t.next())
+    names = [tok.value for tok in tokens]
+    assert 'typedef' in names
+    assert 'struct' in names
+    assert 'uint32' in names
+    assert 'Foo_t' in names
+
+
+def test_match():
+    t = Tokenizer("typedef struct")
+    assert t.match(TokenType.Symbol, "typedef") is not None
+    assert t.match(TokenType.Symbol, "struct") is not None
+    assert t.at_end()

--- a/variants/reference_project/config.yaml
+++ b/variants/reference_project/config.yaml
@@ -1,0 +1,69 @@
+project:
+  name: reference_project
+  description: "Reference project for adapter generation"
+  generic_version_sentinel: 9999
+
+preprocessor:
+  type: builtin
+
+header_sources:
+  - path: "headers/v1"
+    version_tag: "v1"
+  - path: "headers/v2"
+    version_tag: "v2"
+  - path: "headers/v3"
+    version_tag: "v3"
+
+additional_includes:
+  - "headers"
+
+types:
+  TelemetryData_t:
+    version_macro: TELEMETRY_DATA_VERSION
+    generate_reverse: true
+    defaults:
+      battery.voltage: "0.0"
+      battery.current: "0.0"
+      battery.charge_percent: "0"
+      signal_quality: "0"
+      vertical_speed: "0.0"
+      airspeed: "0.0"
+      satellite_count: "0"
+      mission_phase: "0"
+      sequence_number: "0"
+    renames:
+      speed: ground_speed
+      status: op_status
+      altitude: altitude_msl
+    field_warnings:
+      op_status:
+        note: "V1-V2 uses bitmask; V3+ uses enum. Byte copy is safe but meaning differs."
+        severity: 1
+      altitude_msl:
+        note: "Was 'altitude' in V1-V2, renamed to 'altitude_msl' in V3."
+        severity: 0
+
+  CommandMessage_t:
+    version_macro: COMMAND_MSG_VERSION
+    generate_reverse: false
+    defaults:
+      source_id: "0"
+      checksum: "0"
+    renames: {}
+    field_warnings: {}
+
+  SystemStatus_t:
+    version_macro: SYSTEM_STATUS_VERSION
+    generate_reverse: false
+    defaults:
+      task_count: "0"
+      free_heap: "0"
+      boot_count: "0"
+    renames: {}
+    field_warnings: {}
+
+handcrafted: []
+
+warnings:
+  min_display_severity: 1
+  color: true

--- a/variants/reference_project/expected_output/converters/generated/Converter_CommandMessage_t.cpp
+++ b/variants/reference_project/expected_output/converters/generated/Converter_CommandMessage_t.cpp
@@ -1,0 +1,105 @@
+#include "Converter_CommandMessage_t.h"
+#include <cstring>
+
+long Converter_CommandMessage_t::ConvertData(
+  uint32_t src_type_tag, unsigned long src_size,
+  const IVersionInfo& src_version,
+  uint32_t dst_type_tag, unsigned long dst_size,
+  const IVersionInfo* dst_version,
+  void* dst_data,
+  void** out_data, unsigned long& out_size)
+{
+  uint32_t src_ver = src_version.GetVersion();
+  CommandMessage_t_V_Gen::CommandMessage_t generic;
+
+  // Forward: source version -> generic
+  switch (src_ver)
+  {
+    case 1:
+      convert_V1_to_Generic(generic, *reinterpret_cast<const CommandMessage_t_V_1::CommandMessage_t*>(dst_data));
+      break;
+    case 2:
+      convert_V2_to_Generic(generic, *reinterpret_cast<const CommandMessage_t_V_2::CommandMessage_t*>(dst_data));
+      break;
+    case 3:
+      convert_V3_to_Generic(generic, *reinterpret_cast<const CommandMessage_t_V_3::CommandMessage_t*>(dst_data));
+      break;
+    default:
+      return -1;
+  }
+
+  // Output generic
+  out_size = sizeof(CommandMessage_t_V_Gen::CommandMessage_t);
+  *out_data = new CommandMessage_t_V_Gen::CommandMessage_t(generic);
+  return 0;
+}
+
+long Converter_CommandMessage_t::GetDefaultValue(
+  uint32_t type_tag, unsigned long size,
+  const IVersionInfo& version,
+  void** default_data, unsigned long& default_size)
+{
+  CommandMessage_t_V_Gen::CommandMessage_t def;
+  memset(&def, 0, sizeof(def));
+  default_size = sizeof(CommandMessage_t_V_Gen::CommandMessage_t);
+  *default_data = new CommandMessage_t_V_Gen::CommandMessage_t(def);
+  return 0;
+}
+
+bool Converter_CommandMessage_t::AreVersionsCompatible(
+  uint32_t src_type_tag, unsigned long src_size,
+  const IVersionInfo& src_version,
+  uint32_t dst_type_tag, unsigned long dst_size,
+  const IVersionInfo& dst_version)
+{
+  return src_version.GetVersion() == dst_version.GetVersion();
+}
+
+void Converter_CommandMessage_t::convert_V1_to_Generic(
+  CommandMessage_t_V_Gen::CommandMessage_t& dest,
+  const CommandMessage_t_V_1::CommandMessage_t& source)
+{
+  memset(&dest, 0, sizeof(dest));
+  dest.command_id = source.command_id;
+  dest.timestamp = source.timestamp;
+  dest.priority = source.priority;
+  for (int i = 0; i < (4 < 8 ? 4 : 8); i++)
+  {
+    dest.params[i] = source.params[i];
+  }
+  dest.source_id = 0;
+  dest.checksum = 0;
+}
+
+void Converter_CommandMessage_t::convert_V2_to_Generic(
+  CommandMessage_t_V_Gen::CommandMessage_t& dest,
+  const CommandMessage_t_V_2::CommandMessage_t& source)
+{
+  memset(&dest, 0, sizeof(dest));
+  dest.command_id = source.command_id;
+  dest.timestamp = source.timestamp;
+  dest.priority = source.priority;
+  for (int i = 0; i < (4 < 8 ? 4 : 8); i++)
+  {
+    dest.params[i] = source.params[i];
+  }
+  dest.source_id = source.source_id;
+  dest.checksum = 0;
+}
+
+void Converter_CommandMessage_t::convert_V3_to_Generic(
+  CommandMessage_t_V_Gen::CommandMessage_t& dest,
+  const CommandMessage_t_V_3::CommandMessage_t& source)
+{
+  memset(&dest, 0, sizeof(dest));
+  dest.command_id = source.command_id;
+  dest.timestamp = source.timestamp;
+  dest.priority = source.priority;
+  for (int i = 0; i < 8; i++)
+  {
+    dest.params[i] = source.params[i];
+  }
+  dest.source_id = source.source_id;
+  dest.checksum = source.checksum;
+}
+

--- a/variants/reference_project/expected_output/converters/generated/Converter_CommandMessage_t.h
+++ b/variants/reference_project/expected_output/converters/generated/Converter_CommandMessage_t.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "adapter_base.h"
+#include "version_info.h"
+#include "data_types/CommandMessage_t.h"
+
+class Converter_CommandMessage_t : public AdapterConverterBase
+{
+  public:
+    static const char* GetConverterTypeName() { return "CommandMessage_t"; }
+    static AdapterConverterBase* Create() { return new Converter_CommandMessage_t(); }
+
+    const char* GetTypeName() const override { return "CommandMessage_t"; }
+
+    long ConvertData(
+      uint32_t src_type_tag, unsigned long src_size,
+      const IVersionInfo& src_version,
+      uint32_t dst_type_tag, unsigned long dst_size,
+      const IVersionInfo* dst_version,
+      void* dst_data,
+      void** out_data, unsigned long& out_size) override;
+
+    long GetDefaultValue(
+      uint32_t type_tag, unsigned long size,
+      const IVersionInfo& version,
+      void** default_data, unsigned long& default_size) override;
+
+    bool AreVersionsCompatible(
+      uint32_t src_type_tag, unsigned long src_size,
+      const IVersionInfo& src_version,
+      uint32_t dst_type_tag, unsigned long dst_size,
+      const IVersionInfo& dst_version) override;
+
+  private:
+    void convert_V1_to_Generic(
+      CommandMessage_t_V_Gen::CommandMessage_t& dest,
+      const CommandMessage_t_V_1::CommandMessage_t& source);
+    void convert_V2_to_Generic(
+      CommandMessage_t_V_Gen::CommandMessage_t& dest,
+      const CommandMessage_t_V_2::CommandMessage_t& source);
+    void convert_V3_to_Generic(
+      CommandMessage_t_V_Gen::CommandMessage_t& dest,
+      const CommandMessage_t_V_3::CommandMessage_t& source);
+};

--- a/variants/reference_project/expected_output/converters/generated/Converter_SystemStatus_t.cpp
+++ b/variants/reference_project/expected_output/converters/generated/Converter_SystemStatus_t.cpp
@@ -1,0 +1,85 @@
+#include "Converter_SystemStatus_t.h"
+#include <cstring>
+
+long Converter_SystemStatus_t::ConvertData(
+  uint32_t src_type_tag, unsigned long src_size,
+  const IVersionInfo& src_version,
+  uint32_t dst_type_tag, unsigned long dst_size,
+  const IVersionInfo* dst_version,
+  void* dst_data,
+  void** out_data, unsigned long& out_size)
+{
+  uint32_t src_ver = src_version.GetVersion();
+  SystemStatus_t_V_Gen::SystemStatus_t generic;
+
+  // Forward: source version -> generic
+  switch (src_ver)
+  {
+    case 1:
+      convert_V1_to_Generic(generic, *reinterpret_cast<const SystemStatus_t_V_1::SystemStatus_t*>(dst_data));
+      break;
+    case 2:
+      convert_V2_to_Generic(generic, *reinterpret_cast<const SystemStatus_t_V_2::SystemStatus_t*>(dst_data));
+      break;
+    case 3:
+      memcpy(&generic, dst_data, sizeof(generic));
+      break;
+    default:
+      return -1;
+  }
+
+  // Output generic
+  out_size = sizeof(SystemStatus_t_V_Gen::SystemStatus_t);
+  *out_data = new SystemStatus_t_V_Gen::SystemStatus_t(generic);
+  return 0;
+}
+
+long Converter_SystemStatus_t::GetDefaultValue(
+  uint32_t type_tag, unsigned long size,
+  const IVersionInfo& version,
+  void** default_data, unsigned long& default_size)
+{
+  SystemStatus_t_V_Gen::SystemStatus_t def;
+  memset(&def, 0, sizeof(def));
+  default_size = sizeof(SystemStatus_t_V_Gen::SystemStatus_t);
+  *default_data = new SystemStatus_t_V_Gen::SystemStatus_t(def);
+  return 0;
+}
+
+bool Converter_SystemStatus_t::AreVersionsCompatible(
+  uint32_t src_type_tag, unsigned long src_size,
+  const IVersionInfo& src_version,
+  uint32_t dst_type_tag, unsigned long dst_size,
+  const IVersionInfo& dst_version)
+{
+  return src_version.GetVersion() == dst_version.GetVersion();
+}
+
+void Converter_SystemStatus_t::convert_V1_to_Generic(
+  SystemStatus_t_V_Gen::SystemStatus_t& dest,
+  const SystemStatus_t_V_1::SystemStatus_t& source)
+{
+  memset(&dest, 0, sizeof(dest));
+  dest.uptime_seconds = source.uptime_seconds;
+  dest.cpu_load = source.cpu_load;
+  dest.memory_usage = source.memory_usage;
+  dest.error_count = source.error_count;
+  dest.task_count = 0;
+  dest.free_heap = 0;
+  dest.boot_count = 0;
+}
+
+void Converter_SystemStatus_t::convert_V2_to_Generic(
+  SystemStatus_t_V_Gen::SystemStatus_t& dest,
+  const SystemStatus_t_V_2::SystemStatus_t& source)
+{
+  memset(&dest, 0, sizeof(dest));
+  dest.uptime_seconds = source.uptime_seconds;
+  dest.cpu_load = source.cpu_load;
+  dest.memory_usage = source.memory_usage;
+  dest.error_count = source.error_count;
+  dest.task_count = source.task_count;
+  dest.free_heap = source.free_heap;
+  dest.boot_count = 0;
+}
+

--- a/variants/reference_project/expected_output/converters/generated/Converter_SystemStatus_t.h
+++ b/variants/reference_project/expected_output/converters/generated/Converter_SystemStatus_t.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "adapter_base.h"
+#include "version_info.h"
+#include "data_types/SystemStatus_t.h"
+
+class Converter_SystemStatus_t : public AdapterConverterBase
+{
+  public:
+    static const char* GetConverterTypeName() { return "SystemStatus_t"; }
+    static AdapterConverterBase* Create() { return new Converter_SystemStatus_t(); }
+
+    const char* GetTypeName() const override { return "SystemStatus_t"; }
+
+    long ConvertData(
+      uint32_t src_type_tag, unsigned long src_size,
+      const IVersionInfo& src_version,
+      uint32_t dst_type_tag, unsigned long dst_size,
+      const IVersionInfo* dst_version,
+      void* dst_data,
+      void** out_data, unsigned long& out_size) override;
+
+    long GetDefaultValue(
+      uint32_t type_tag, unsigned long size,
+      const IVersionInfo& version,
+      void** default_data, unsigned long& default_size) override;
+
+    bool AreVersionsCompatible(
+      uint32_t src_type_tag, unsigned long src_size,
+      const IVersionInfo& src_version,
+      uint32_t dst_type_tag, unsigned long dst_size,
+      const IVersionInfo& dst_version) override;
+
+  private:
+    void convert_V1_to_Generic(
+      SystemStatus_t_V_Gen::SystemStatus_t& dest,
+      const SystemStatus_t_V_1::SystemStatus_t& source);
+    void convert_V2_to_Generic(
+      SystemStatus_t_V_Gen::SystemStatus_t& dest,
+      const SystemStatus_t_V_2::SystemStatus_t& source);
+};

--- a/variants/reference_project/expected_output/converters/generated/Converter_TelemetryData_t.cpp
+++ b/variants/reference_project/expected_output/converters/generated/Converter_TelemetryData_t.cpp
@@ -1,0 +1,196 @@
+#include "Converter_TelemetryData_t.h"
+#include <cstring>
+
+long Converter_TelemetryData_t::ConvertData(
+  uint32_t src_type_tag, unsigned long src_size,
+  const IVersionInfo& src_version,
+  uint32_t dst_type_tag, unsigned long dst_size,
+  const IVersionInfo* dst_version,
+  void* dst_data,
+  void** out_data, unsigned long& out_size)
+{
+  uint32_t src_ver = src_version.GetVersion();
+  TelemetryData_t_V_Gen::TelemetryData_t generic;
+
+  // Forward: source version -> generic
+  switch (src_ver)
+  {
+    case 1:
+      convert_V1_to_Generic(generic, *reinterpret_cast<const TelemetryData_t_V_1::TelemetryData_t*>(dst_data));
+      break;
+    case 2:
+      convert_V2_to_Generic(generic, *reinterpret_cast<const TelemetryData_t_V_2::TelemetryData_t*>(dst_data));
+      break;
+    case 3:
+      convert_V3_to_Generic(generic, *reinterpret_cast<const TelemetryData_t_V_3::TelemetryData_t*>(dst_data));
+      break;
+    default:
+      return -1;
+  }
+
+  // Output generic
+  out_size = sizeof(TelemetryData_t_V_Gen::TelemetryData_t);
+  *out_data = new TelemetryData_t_V_Gen::TelemetryData_t(generic);
+  return 0;
+}
+
+long Converter_TelemetryData_t::GetDefaultValue(
+  uint32_t type_tag, unsigned long size,
+  const IVersionInfo& version,
+  void** default_data, unsigned long& default_size)
+{
+  TelemetryData_t_V_Gen::TelemetryData_t def;
+  memset(&def, 0, sizeof(def));
+  default_size = sizeof(TelemetryData_t_V_Gen::TelemetryData_t);
+  *default_data = new TelemetryData_t_V_Gen::TelemetryData_t(def);
+  return 0;
+}
+
+bool Converter_TelemetryData_t::AreVersionsCompatible(
+  uint32_t src_type_tag, unsigned long src_size,
+  const IVersionInfo& src_version,
+  uint32_t dst_type_tag, unsigned long dst_size,
+  const IVersionInfo& dst_version)
+{
+  return src_version.GetVersion() == dst_version.GetVersion();
+}
+
+void Converter_TelemetryData_t::convert_V1_to_Generic(
+  TelemetryData_t_V_Gen::TelemetryData_t& dest,
+  const TelemetryData_t_V_1::TelemetryData_t& source)
+{
+  memset(&dest, 0, sizeof(dest));
+  dest.timestamp = source.timestamp;
+  dest.ground_speed = source.speed;
+  dest.altitude_msl = source.altitude;
+  dest.heading = source.heading;
+  dest.latitude = source.latitude;
+  dest.longitude = source.longitude;
+  dest.op_status = source.status;
+  for (int i = 0; i < (32 < 64 ? 32 : 64); i++)
+  {
+    dest.payload[i] = source.payload[i];
+  }
+  dest.vertical_speed = 0.0;
+  dest.signal_quality = 0;
+  // Field 'battery' not in source, zero-initialized by memset
+  dest.airspeed = 0.0;
+  dest.satellite_count = 0;
+  dest.mission_phase = 0;
+  dest.sequence_number = 0;
+}
+
+void Converter_TelemetryData_t::convert_V2_to_Generic(
+  TelemetryData_t_V_Gen::TelemetryData_t& dest,
+  const TelemetryData_t_V_2::TelemetryData_t& source)
+{
+  memset(&dest, 0, sizeof(dest));
+  dest.timestamp = source.timestamp;
+  dest.ground_speed = source.speed;
+  dest.altitude_msl = source.altitude;
+  dest.heading = source.heading;
+  dest.latitude = source.latitude;
+  dest.longitude = source.longitude;
+  dest.op_status = source.status;
+  for (int i = 0; i < 64; i++)
+  {
+    dest.payload[i] = source.payload[i];
+  }
+  dest.vertical_speed = source.vertical_speed;
+  dest.signal_quality = source.signal_quality;
+  memcpy(&dest.battery, &source.battery, sizeof(dest.battery));
+  dest.airspeed = 0.0;
+  dest.satellite_count = 0;
+  dest.mission_phase = 0;
+  dest.sequence_number = 0;
+}
+
+void Converter_TelemetryData_t::convert_V3_to_Generic(
+  TelemetryData_t_V_Gen::TelemetryData_t& dest,
+  const TelemetryData_t_V_3::TelemetryData_t& source)
+{
+  memset(&dest, 0, sizeof(dest));
+  dest.timestamp = source.timestamp;
+  dest.ground_speed = source.ground_speed;
+  dest.altitude_msl = source.altitude_msl;
+  dest.heading = source.heading;
+  dest.latitude = source.latitude;
+  dest.longitude = source.longitude;
+  dest.op_status = source.op_status;
+  for (int i = 0; i < 64; i++)
+  {
+    dest.payload[i] = source.payload[i];
+  }
+  dest.vertical_speed = source.vertical_speed;
+  dest.signal_quality = source.signal_quality;
+  memcpy(&dest.battery, &source.battery, sizeof(dest.battery));
+  dest.airspeed = source.airspeed;
+  dest.satellite_count = source.satellite_count;
+  dest.mission_phase = source.mission_phase;
+  dest.sequence_number = source.sequence_number;
+}
+
+void Converter_TelemetryData_t::convert_Generic_to_V1(
+  TelemetryData_t_V_1::TelemetryData_t& dest,
+  const TelemetryData_t_V_Gen::TelemetryData_t& source)
+{
+  memset(&dest, 0, sizeof(dest));
+  dest.timestamp = source.timestamp;
+  dest.speed = source.ground_speed;
+  dest.altitude = source.altitude_msl;
+  dest.heading = source.heading;
+  dest.latitude = source.latitude;
+  dest.longitude = source.longitude;
+  dest.status = source.op_status;
+  for (int i = 0; i < (64 < 32 ? 64 : 32); i++)
+  {
+    dest.payload[i] = source.payload[i];
+  }
+}
+
+void Converter_TelemetryData_t::convert_Generic_to_V2(
+  TelemetryData_t_V_2::TelemetryData_t& dest,
+  const TelemetryData_t_V_Gen::TelemetryData_t& source)
+{
+  memset(&dest, 0, sizeof(dest));
+  dest.timestamp = source.timestamp;
+  dest.speed = source.ground_speed;
+  dest.altitude = source.altitude_msl;
+  dest.heading = source.heading;
+  dest.latitude = source.latitude;
+  dest.longitude = source.longitude;
+  dest.vertical_speed = source.vertical_speed;
+  dest.status = source.op_status;
+  dest.signal_quality = source.signal_quality;
+  for (int i = 0; i < 64; i++)
+  {
+    dest.payload[i] = source.payload[i];
+  }
+  memcpy(&dest.battery, &source.battery, sizeof(dest.battery));
+}
+
+void Converter_TelemetryData_t::convert_Generic_to_V3(
+  TelemetryData_t_V_3::TelemetryData_t& dest,
+  const TelemetryData_t_V_Gen::TelemetryData_t& source)
+{
+  memset(&dest, 0, sizeof(dest));
+  dest.timestamp = source.timestamp;
+  dest.ground_speed = source.ground_speed;
+  dest.altitude_msl = source.altitude_msl;
+  dest.heading = source.heading;
+  dest.latitude = source.latitude;
+  dest.longitude = source.longitude;
+  dest.vertical_speed = source.vertical_speed;
+  dest.airspeed = source.airspeed;
+  dest.op_status = source.op_status;
+  dest.signal_quality = source.signal_quality;
+  dest.satellite_count = source.satellite_count;
+  dest.mission_phase = source.mission_phase;
+  dest.sequence_number = source.sequence_number;
+  for (int i = 0; i < 64; i++)
+  {
+    dest.payload[i] = source.payload[i];
+  }
+  memcpy(&dest.battery, &source.battery, sizeof(dest.battery));
+}
+

--- a/variants/reference_project/expected_output/converters/generated/Converter_TelemetryData_t.h
+++ b/variants/reference_project/expected_output/converters/generated/Converter_TelemetryData_t.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "adapter_base.h"
+#include "version_info.h"
+#include "data_types/TelemetryData_t.h"
+
+class Converter_TelemetryData_t : public AdapterConverterBase
+{
+  public:
+    static const char* GetConverterTypeName() { return "TelemetryData_t"; }
+    static AdapterConverterBase* Create() { return new Converter_TelemetryData_t(); }
+
+    const char* GetTypeName() const override { return "TelemetryData_t"; }
+
+    long ConvertData(
+      uint32_t src_type_tag, unsigned long src_size,
+      const IVersionInfo& src_version,
+      uint32_t dst_type_tag, unsigned long dst_size,
+      const IVersionInfo* dst_version,
+      void* dst_data,
+      void** out_data, unsigned long& out_size) override;
+
+    long GetDefaultValue(
+      uint32_t type_tag, unsigned long size,
+      const IVersionInfo& version,
+      void** default_data, unsigned long& default_size) override;
+
+    bool AreVersionsCompatible(
+      uint32_t src_type_tag, unsigned long src_size,
+      const IVersionInfo& src_version,
+      uint32_t dst_type_tag, unsigned long dst_size,
+      const IVersionInfo& dst_version) override;
+
+  private:
+    void convert_V1_to_Generic(
+      TelemetryData_t_V_Gen::TelemetryData_t& dest,
+      const TelemetryData_t_V_1::TelemetryData_t& source);
+    void convert_V2_to_Generic(
+      TelemetryData_t_V_Gen::TelemetryData_t& dest,
+      const TelemetryData_t_V_2::TelemetryData_t& source);
+    void convert_V3_to_Generic(
+      TelemetryData_t_V_Gen::TelemetryData_t& dest,
+      const TelemetryData_t_V_3::TelemetryData_t& source);
+    void convert_Generic_to_V1(
+      TelemetryData_t_V_1::TelemetryData_t& dest,
+      const TelemetryData_t_V_Gen::TelemetryData_t& source);
+    void convert_Generic_to_V2(
+      TelemetryData_t_V_2::TelemetryData_t& dest,
+      const TelemetryData_t_V_Gen::TelemetryData_t& source);
+    void convert_Generic_to_V3(
+      TelemetryData_t_V_3::TelemetryData_t& dest,
+      const TelemetryData_t_V_Gen::TelemetryData_t& source);
+};

--- a/variants/reference_project/expected_output/converters/generated/converters.cpp
+++ b/variants/reference_project/expected_output/converters/generated/converters.cpp
@@ -1,0 +1,24 @@
+#include <vector>
+#include <string>
+#include <functional>
+#include "Converter_CommandMessage_t.h"
+#include "Converter_SystemStatus_t.h"
+#include "Converter_TelemetryData_t.h"
+
+struct ConverterRegistration
+{
+  std::string type_name;
+  std::function<AdapterConverterBase*()> factory;
+};
+
+std::vector<ConverterRegistration> GetGeneratedAdapters()
+{
+  return {
+    { Converter_CommandMessage_t::GetConverterTypeName(),
+      Converter_CommandMessage_t::Create },
+    { Converter_SystemStatus_t::GetConverterTypeName(),
+      Converter_SystemStatus_t::Create },
+    { Converter_TelemetryData_t::GetConverterTypeName(),
+      Converter_TelemetryData_t::Create }
+  };
+}

--- a/variants/reference_project/expected_output/data_types/CommandMessage_t.h
+++ b/variants/reference_project/expected_output/data_types/CommandMessage_t.h
@@ -1,0 +1,65 @@
+#pragma once
+#include "platform_types.h"
+
+#ifdef COMMAND_MSG_VERSION
+static_assert(COMMAND_MSG_VERSION != 9999,
+  "Version 9999 is reserved as the generic adapter hub version");
+#endif
+
+namespace CommandMessage_t_V_1
+{
+  static const uint32_t VERSION = 1;
+
+  typedef struct
+  {
+    uint32 command_id;
+    uint32 timestamp;
+    uint8 priority;
+    float32 params[4];
+  } CommandMessage_t;
+} // namespace CommandMessage_t_V_1
+
+namespace CommandMessage_t_V_2
+{
+  static const uint32_t VERSION = 2;
+
+  typedef struct
+  {
+    uint32 command_id;
+    uint32 timestamp;
+    uint8 priority;
+    uint8 source_id;
+    float32 params[4];
+  } CommandMessage_t;
+} // namespace CommandMessage_t_V_2
+
+namespace CommandMessage_t_V_3
+{
+  static const uint32_t VERSION = 3;
+
+  typedef struct
+  {
+    uint32 command_id;
+    uint32 timestamp;
+    uint8 priority;
+    uint8 source_id;
+    uint32 checksum;
+    float32 params[8];
+  } CommandMessage_t;
+} // namespace CommandMessage_t_V_3
+
+namespace CommandMessage_t_V_Gen
+{
+  static const uint32_t VERSION = 9999;
+
+  typedef struct
+  {
+    uint32 command_id;
+    uint32 timestamp;
+    uint8 priority;
+    float32 params[8];
+    uint8 source_id;
+    uint32 checksum;
+  } CommandMessage_t;
+} // namespace CommandMessage_t_V_Gen
+

--- a/variants/reference_project/expected_output/data_types/SystemStatus_t.h
+++ b/variants/reference_project/expected_output/data_types/SystemStatus_t.h
@@ -1,0 +1,68 @@
+#pragma once
+#include "platform_types.h"
+
+#ifdef SYSTEM_STATUS_VERSION
+static_assert(SYSTEM_STATUS_VERSION != 9999,
+  "Version 9999 is reserved as the generic adapter hub version");
+#endif
+
+namespace SystemStatus_t_V_1
+{
+  static const uint32_t VERSION = 1;
+
+  typedef struct
+  {
+    uint32 uptime_seconds;
+    uint8 cpu_load;
+    uint8 memory_usage;
+    uint8 error_count;
+  } SystemStatus_t;
+} // namespace SystemStatus_t_V_1
+
+namespace SystemStatus_t_V_2
+{
+  static const uint32_t VERSION = 2;
+
+  typedef struct
+  {
+    uint32 uptime_seconds;
+    uint8 cpu_load;
+    uint8 memory_usage;
+    uint8 error_count;
+    uint16 task_count;
+    uint32 free_heap;
+  } SystemStatus_t;
+} // namespace SystemStatus_t_V_2
+
+namespace SystemStatus_t_V_3
+{
+  static const uint32_t VERSION = 3;
+
+  typedef struct
+  {
+    uint32 uptime_seconds;
+    uint8 cpu_load;
+    uint8 memory_usage;
+    uint8 error_count;
+    uint16 task_count;
+    uint32 free_heap;
+    uint32 boot_count;
+  } SystemStatus_t;
+} // namespace SystemStatus_t_V_3
+
+namespace SystemStatus_t_V_Gen
+{
+  static const uint32_t VERSION = 9999;
+
+  typedef struct
+  {
+    uint32 uptime_seconds;
+    uint8 cpu_load;
+    uint8 memory_usage;
+    uint8 error_count;
+    uint16 task_count;
+    uint32 free_heap;
+    uint32 boot_count;
+  } SystemStatus_t;
+} // namespace SystemStatus_t_V_Gen
+

--- a/variants/reference_project/expected_output/data_types/TelemetryData_t.h
+++ b/variants/reference_project/expected_output/data_types/TelemetryData_t.h
@@ -1,0 +1,114 @@
+#pragma once
+#include "platform_types.h"
+
+#ifdef TELEMETRY_DATA_VERSION
+static_assert(TELEMETRY_DATA_VERSION != 9999,
+  "Version 9999 is reserved as the generic adapter hub version");
+#endif
+
+namespace TelemetryData_t_V_1
+{
+  static const uint32_t VERSION = 1;
+
+  typedef struct
+  {
+    uint32 timestamp;
+    float32 speed;
+    float32 altitude;
+    float32 heading;
+    float32 latitude;
+    float32 longitude;
+    uint8 status;
+    uint8 payload[32];
+  } TelemetryData_t;
+} // namespace TelemetryData_t_V_1
+
+namespace TelemetryData_t_V_2
+{
+  static const uint32_t VERSION = 2;
+
+  typedef struct
+  {
+    float32 voltage;
+    float32 current;
+    uint8 charge_percent;
+  } BatteryInfo_t;
+
+  typedef struct
+  {
+    uint32 timestamp;
+    float32 speed;
+    float32 altitude;
+    float32 heading;
+    float32 latitude;
+    float32 longitude;
+    float32 vertical_speed;
+    uint8 status;
+    uint8 signal_quality;
+    uint8 payload[64];
+    BatteryInfo_t battery;
+  } TelemetryData_t;
+} // namespace TelemetryData_t_V_2
+
+namespace TelemetryData_t_V_3
+{
+  static const uint32_t VERSION = 3;
+
+  typedef struct
+  {
+    float32 voltage;
+    float32 current;
+    uint8 charge_percent;
+  } BatteryInfo_t;
+
+  typedef struct
+  {
+    uint32 timestamp;
+    float32 ground_speed;
+    float32 altitude_msl;
+    float32 heading;
+    float32 latitude;
+    float32 longitude;
+    float32 vertical_speed;
+    float32 airspeed;
+    uint8 op_status;
+    uint8 signal_quality;
+    uint8 satellite_count;
+    uint8 mission_phase;
+    uint32 sequence_number;
+    uint8 payload[64];
+    BatteryInfo_t battery;
+  } TelemetryData_t;
+} // namespace TelemetryData_t_V_3
+
+namespace TelemetryData_t_V_Gen
+{
+  static const uint32_t VERSION = 9999;
+
+  typedef struct
+  {
+    float32 voltage;
+    float32 current;
+    uint8 charge_percent;
+  } BatteryInfo_t;
+
+  typedef struct
+  {
+    uint32 timestamp;
+    float32 ground_speed;
+    float32 altitude_msl;
+    float32 heading;
+    float32 latitude;
+    float32 longitude;
+    uint8 op_status;
+    uint8 payload[64];
+    float32 vertical_speed;
+    uint8 signal_quality;
+    BatteryInfo_t battery;
+    float32 airspeed;
+    uint8 satellite_count;
+    uint8 mission_phase;
+    uint32 sequence_number;
+  } TelemetryData_t;
+} // namespace TelemetryData_t_V_Gen
+

--- a/variants/reference_project/expected_output/data_types/platform_types.h
+++ b/variants/reference_project/expected_output/data_types/platform_types.h
@@ -1,0 +1,16 @@
+#ifndef PLATFORM_TYPES_H
+#define PLATFORM_TYPES_H
+
+typedef unsigned char      uint8;
+typedef signed char        sint8;
+typedef unsigned short     uint16;
+typedef signed short       sint16;
+typedef unsigned int       uint32;
+typedef signed int         sint32;
+typedef unsigned long long uint64;
+typedef signed long long   sint64;
+typedef float              float32;
+typedef double             float64;
+typedef unsigned char      boolean;
+
+#endif /* PLATFORM_TYPES_H */

--- a/variants/reference_project/expected_output/field_provenance.json
+++ b/variants/reference_project/expected_output/field_provenance.json
@@ -1,0 +1,544 @@
+{
+  "TelemetryData_t": {
+    "timestamp": {
+      "generic_type": "uint32",
+      "versions": {
+        "1": {
+          "type": "uint32",
+          "field_name": "timestamp"
+        },
+        "2": {
+          "type": "uint32",
+          "field_name": "timestamp"
+        },
+        "3": {
+          "type": "uint32",
+          "field_name": "timestamp"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "ground_speed": {
+      "generic_type": "float32",
+      "versions": {
+        "1": {
+          "type": "float32",
+          "field_name": "speed",
+          "rename_from": "speed"
+        },
+        "2": {
+          "type": "float32",
+          "field_name": "speed",
+          "rename_from": "speed"
+        },
+        "3": {
+          "type": "float32",
+          "field_name": "ground_speed"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "altitude_msl": {
+      "generic_type": "float32",
+      "versions": {
+        "1": {
+          "type": "float32",
+          "field_name": "altitude",
+          "rename_from": "altitude"
+        },
+        "2": {
+          "type": "float32",
+          "field_name": "altitude",
+          "rename_from": "altitude"
+        },
+        "3": {
+          "type": "float32",
+          "field_name": "altitude_msl"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [
+        {
+          "severity": 0,
+          "note": "Was 'altitude' in V1-V2, renamed to 'altitude_msl' in V3."
+        }
+      ]
+    },
+    "heading": {
+      "generic_type": "float32",
+      "versions": {
+        "1": {
+          "type": "float32",
+          "field_name": "heading"
+        },
+        "2": {
+          "type": "float32",
+          "field_name": "heading"
+        },
+        "3": {
+          "type": "float32",
+          "field_name": "heading"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "latitude": {
+      "generic_type": "float32",
+      "versions": {
+        "1": {
+          "type": "float32",
+          "field_name": "latitude"
+        },
+        "2": {
+          "type": "float32",
+          "field_name": "latitude"
+        },
+        "3": {
+          "type": "float32",
+          "field_name": "latitude"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "longitude": {
+      "generic_type": "float32",
+      "versions": {
+        "1": {
+          "type": "float32",
+          "field_name": "longitude"
+        },
+        "2": {
+          "type": "float32",
+          "field_name": "longitude"
+        },
+        "3": {
+          "type": "float32",
+          "field_name": "longitude"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "op_status": {
+      "generic_type": "uint8",
+      "versions": {
+        "1": {
+          "type": "uint8",
+          "field_name": "status",
+          "rename_from": "status"
+        },
+        "2": {
+          "type": "uint8",
+          "field_name": "status",
+          "rename_from": "status"
+        },
+        "3": {
+          "type": "uint8",
+          "field_name": "op_status"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [
+        {
+          "severity": 1,
+          "note": "V1-V2 uses bitmask; V3+ uses enum. Byte copy is safe but meaning differs."
+        }
+      ]
+    },
+    "payload": {
+      "generic_type": "uint8",
+      "versions": {
+        "1": {
+          "type": "uint8",
+          "field_name": "payload"
+        },
+        "2": {
+          "type": "uint8",
+          "field_name": "payload"
+        },
+        "3": {
+          "type": "uint8",
+          "field_name": "payload"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "vertical_speed": {
+      "generic_type": "float32",
+      "versions": {
+        "1": null,
+        "2": {
+          "type": "float32",
+          "field_name": "vertical_speed"
+        },
+        "3": {
+          "type": "float32",
+          "field_name": "vertical_speed"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [],
+      "default_applied_for": [
+        1
+      ]
+    },
+    "signal_quality": {
+      "generic_type": "uint8",
+      "versions": {
+        "1": null,
+        "2": {
+          "type": "uint8",
+          "field_name": "signal_quality"
+        },
+        "3": {
+          "type": "uint8",
+          "field_name": "signal_quality"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [],
+      "default_applied_for": [
+        1
+      ]
+    },
+    "battery": {
+      "generic_type": "BatteryInfo_t",
+      "versions": {
+        "1": null,
+        "2": {
+          "type": "BatteryInfo_t",
+          "field_name": "battery"
+        },
+        "3": {
+          "type": "BatteryInfo_t",
+          "field_name": "battery"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [],
+      "default_applied_for": [
+        1
+      ]
+    },
+    "airspeed": {
+      "generic_type": "float32",
+      "versions": {
+        "1": null,
+        "2": null,
+        "3": {
+          "type": "float32",
+          "field_name": "airspeed"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [],
+      "default_applied_for": [
+        1,
+        2
+      ]
+    },
+    "satellite_count": {
+      "generic_type": "uint8",
+      "versions": {
+        "1": null,
+        "2": null,
+        "3": {
+          "type": "uint8",
+          "field_name": "satellite_count"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [],
+      "default_applied_for": [
+        1,
+        2
+      ]
+    },
+    "mission_phase": {
+      "generic_type": "uint8",
+      "versions": {
+        "1": null,
+        "2": null,
+        "3": {
+          "type": "uint8",
+          "field_name": "mission_phase"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [],
+      "default_applied_for": [
+        1,
+        2
+      ]
+    },
+    "sequence_number": {
+      "generic_type": "uint32",
+      "versions": {
+        "1": null,
+        "2": null,
+        "3": {
+          "type": "uint32",
+          "field_name": "sequence_number"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [],
+      "default_applied_for": [
+        1,
+        2
+      ]
+    }
+  },
+  "CommandMessage_t": {
+    "command_id": {
+      "generic_type": "uint32",
+      "versions": {
+        "1": {
+          "type": "uint32",
+          "field_name": "command_id"
+        },
+        "2": {
+          "type": "uint32",
+          "field_name": "command_id"
+        },
+        "3": {
+          "type": "uint32",
+          "field_name": "command_id"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "timestamp": {
+      "generic_type": "uint32",
+      "versions": {
+        "1": {
+          "type": "uint32",
+          "field_name": "timestamp"
+        },
+        "2": {
+          "type": "uint32",
+          "field_name": "timestamp"
+        },
+        "3": {
+          "type": "uint32",
+          "field_name": "timestamp"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "priority": {
+      "generic_type": "uint8",
+      "versions": {
+        "1": {
+          "type": "uint8",
+          "field_name": "priority"
+        },
+        "2": {
+          "type": "uint8",
+          "field_name": "priority"
+        },
+        "3": {
+          "type": "uint8",
+          "field_name": "priority"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "params": {
+      "generic_type": "float32",
+      "versions": {
+        "1": {
+          "type": "float32",
+          "field_name": "params"
+        },
+        "2": {
+          "type": "float32",
+          "field_name": "params"
+        },
+        "3": {
+          "type": "float32",
+          "field_name": "params"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "source_id": {
+      "generic_type": "uint8",
+      "versions": {
+        "1": null,
+        "2": {
+          "type": "uint8",
+          "field_name": "source_id"
+        },
+        "3": {
+          "type": "uint8",
+          "field_name": "source_id"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [],
+      "default_applied_for": [
+        1
+      ]
+    },
+    "checksum": {
+      "generic_type": "uint32",
+      "versions": {
+        "1": null,
+        "2": null,
+        "3": {
+          "type": "uint32",
+          "field_name": "checksum"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [],
+      "default_applied_for": [
+        1,
+        2
+      ]
+    }
+  },
+  "SystemStatus_t": {
+    "uptime_seconds": {
+      "generic_type": "uint32",
+      "versions": {
+        "1": {
+          "type": "uint32",
+          "field_name": "uptime_seconds"
+        },
+        "2": {
+          "type": "uint32",
+          "field_name": "uptime_seconds"
+        },
+        "3": {
+          "type": "uint32",
+          "field_name": "uptime_seconds"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "cpu_load": {
+      "generic_type": "uint8",
+      "versions": {
+        "1": {
+          "type": "uint8",
+          "field_name": "cpu_load"
+        },
+        "2": {
+          "type": "uint8",
+          "field_name": "cpu_load"
+        },
+        "3": {
+          "type": "uint8",
+          "field_name": "cpu_load"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "memory_usage": {
+      "generic_type": "uint8",
+      "versions": {
+        "1": {
+          "type": "uint8",
+          "field_name": "memory_usage"
+        },
+        "2": {
+          "type": "uint8",
+          "field_name": "memory_usage"
+        },
+        "3": {
+          "type": "uint8",
+          "field_name": "memory_usage"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "error_count": {
+      "generic_type": "uint8",
+      "versions": {
+        "1": {
+          "type": "uint8",
+          "field_name": "error_count"
+        },
+        "2": {
+          "type": "uint8",
+          "field_name": "error_count"
+        },
+        "3": {
+          "type": "uint8",
+          "field_name": "error_count"
+        }
+      },
+      "type_compatible": true,
+      "warnings": []
+    },
+    "task_count": {
+      "generic_type": "uint16",
+      "versions": {
+        "1": null,
+        "2": {
+          "type": "uint16",
+          "field_name": "task_count"
+        },
+        "3": {
+          "type": "uint16",
+          "field_name": "task_count"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [],
+      "default_applied_for": [
+        1
+      ]
+    },
+    "free_heap": {
+      "generic_type": "uint32",
+      "versions": {
+        "1": null,
+        "2": {
+          "type": "uint32",
+          "field_name": "free_heap"
+        },
+        "3": {
+          "type": "uint32",
+          "field_name": "free_heap"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [],
+      "default_applied_for": [
+        1
+      ]
+    },
+    "boot_count": {
+      "generic_type": "uint32",
+      "versions": {
+        "1": null,
+        "2": null,
+        "3": {
+          "type": "uint32",
+          "field_name": "boot_count"
+        }
+      },
+      "type_compatible": true,
+      "warnings": [],
+      "default_applied_for": [
+        1,
+        2
+      ]
+    }
+  }
+}

--- a/variants/reference_project/headers/platform_types.h
+++ b/variants/reference_project/headers/platform_types.h
@@ -1,0 +1,16 @@
+#ifndef PLATFORM_TYPES_H
+#define PLATFORM_TYPES_H
+
+typedef unsigned char      uint8;
+typedef signed char        sint8;
+typedef unsigned short     uint16;
+typedef signed short       sint16;
+typedef unsigned int       uint32;
+typedef signed int         sint32;
+typedef unsigned long long uint64;
+typedef signed long long   sint64;
+typedef float              float32;
+typedef double             float64;
+typedef unsigned char      boolean;
+
+#endif /* PLATFORM_TYPES_H */

--- a/variants/reference_project/headers/v1/telemetry_types.h
+++ b/variants/reference_project/headers/v1/telemetry_types.h
@@ -1,0 +1,38 @@
+#ifndef TELEMETRY_TYPES_V1_H
+#define TELEMETRY_TYPES_V1_H
+
+#include "platform_types.h"
+
+#define TELEMETRY_DATA_VERSION 1
+#define COMMAND_MSG_VERSION 1
+#define SYSTEM_STATUS_VERSION 1
+
+#define MAX_PAYLOAD_SIZE 32
+#define MAX_CMD_PARAMS 4
+
+typedef struct {
+  uint32 timestamp;
+  float32 speed;
+  float32 altitude;
+  float32 heading;
+  float32 latitude;
+  float32 longitude;
+  uint8 status;
+  uint8 payload[MAX_PAYLOAD_SIZE];
+} TelemetryData_t;
+
+typedef struct {
+  uint32 command_id;
+  uint32 timestamp;
+  uint8 priority;
+  float32 params[MAX_CMD_PARAMS];
+} CommandMessage_t;
+
+typedef struct {
+  uint32 uptime_seconds;
+  uint8 cpu_load;
+  uint8 memory_usage;
+  uint8 error_count;
+} SystemStatus_t;
+
+#endif /* TELEMETRY_TYPES_V1_H */

--- a/variants/reference_project/headers/v2/telemetry_types.h
+++ b/variants/reference_project/headers/v2/telemetry_types.h
@@ -1,0 +1,50 @@
+#ifndef TELEMETRY_TYPES_V2_H
+#define TELEMETRY_TYPES_V2_H
+
+#include "platform_types.h"
+
+#define TELEMETRY_DATA_VERSION 2
+#define COMMAND_MSG_VERSION 2
+#define SYSTEM_STATUS_VERSION 2
+
+#define MAX_PAYLOAD_SIZE 64
+#define MAX_CMD_PARAMS 4
+
+typedef struct {
+  float32 voltage;
+  float32 current;
+  uint8 charge_percent;
+} BatteryInfo_t;
+
+typedef struct {
+  uint32 timestamp;
+  float32 speed;
+  float32 altitude;
+  float32 heading;
+  float32 latitude;
+  float32 longitude;
+  float32 vertical_speed;
+  uint8 status;
+  uint8 signal_quality;
+  uint8 payload[MAX_PAYLOAD_SIZE];
+  BatteryInfo_t battery;
+} TelemetryData_t;
+
+typedef struct {
+  uint32 command_id;
+  uint32 timestamp;
+  uint8 priority;
+  uint8 source_id;
+  float32 params[MAX_CMD_PARAMS];
+} CommandMessage_t;
+
+typedef struct {
+  uint32 uptime_seconds;
+  uint8 cpu_load;
+  uint8 memory_usage;
+  uint8 error_count;
+  uint16 task_count;
+  uint32 free_heap;
+} SystemStatus_t;
+
+#endif /* TELEMETRY_TYPES_V2_H */

--- a/variants/reference_project/headers/v3/telemetry_types.h
+++ b/variants/reference_project/headers/v3/telemetry_types.h
@@ -1,0 +1,56 @@
+#ifndef TELEMETRY_TYPES_V3_H
+#define TELEMETRY_TYPES_V3_H
+
+#include "platform_types.h"
+
+#define TELEMETRY_DATA_VERSION 3
+#define COMMAND_MSG_VERSION 3
+#define SYSTEM_STATUS_VERSION 3
+
+#define MAX_PAYLOAD_SIZE 64
+#define MAX_CMD_PARAMS 8
+
+typedef struct {
+  float32 voltage;
+  float32 current;
+  uint8 charge_percent;
+} BatteryInfo_t;
+
+typedef struct {
+  uint32 timestamp;
+  float32 ground_speed;
+  float32 altitude_msl;
+  float32 heading;
+  float32 latitude;
+  float32 longitude;
+  float32 vertical_speed;
+  float32 airspeed;
+  uint8 op_status;
+  uint8 signal_quality;
+  uint8 satellite_count;
+  uint8 mission_phase;
+  uint32 sequence_number;
+  uint8 payload[MAX_PAYLOAD_SIZE];
+  BatteryInfo_t battery;
+} TelemetryData_t;
+
+typedef struct {
+  uint32 command_id;
+  uint32 timestamp;
+  uint8 priority;
+  uint8 source_id;
+  uint32 checksum;
+  float32 params[MAX_CMD_PARAMS];
+} CommandMessage_t;
+
+typedef struct {
+  uint32 uptime_seconds;
+  uint8 cpu_load;
+  uint8 memory_usage;
+  uint8 error_count;
+  uint16 task_count;
+  uint32 free_heap;
+  uint32 boot_count;
+} SystemStatus_t;
+
+#endif /* TELEMETRY_TYPES_V3_H */


### PR DESCRIPTION
## Summary

- Complete implementation of the ductape universal schema adapter generator across all 10 build phases
- Parses versioned C struct headers (v1/v2/v3) and generates compilable C++ converter code using a hub-and-spoke pattern
- Config-driven (YAML in, C++ out) with field renames, defaults, array min-copy, and structural identity detection

## What's included

- **Preprocessor & expression evaluator** — comment stripping, `#define` capture, constant integer expression evaluation
- **Tokenizer & recursive-descent parser** — handles typedef structs, enums, aliases, arrays, bitfields, tagged typedefs, C++ style structs
- **Config loader** — YAML validation with actionable error messages
- **Type registry** — collects all types across all versions, builds generic superset, semantic conflict detection
- **Pointer abstractions** — StructPointer (3-step fuzzy lookup + AmbiguousMemberError), ValuePointer, WarningNullPointer
- **C++ code generation** — data type headers with namespaces, converter classes with field-by-field copy, factory registration
- **Field provenance** — JSON report tracking field origins, renames, defaults, and warnings across versions
- **CLI** — `ductape generate` and `ductape verify` subcommands
- **Golden files** — regression testing via expected output comparison

## Test plan

- [x] `python3 -m pytest tests/ -v` — 79/79 tests pass
- [x] `ductape generate --config variants/reference_project/config.yaml --output build/` — runs clean
- [x] `test -f build/field_provenance.json` — exists with all 3 types
- [x] `g++ -c build/converters/generated/*.cpp -Ibuild -Iruntime_reference -Ibuild/converters/generated -std=c++17` — compiles with zero errors
- [x] `ductape verify --config variants/reference_project/config.yaml --expected variants/reference_project/expected_output/` — passes

https://claude.ai/code/session_011srL1jWdiyGnoWmA3R7Nrp