### PR TITLE
Implement ductape code generator with full documentation and CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ types:
 - **Semantic conflict detection** — warns when field types differ across versions
 - **Field provenance report** — JSON audit trail for all field mappings
 
+## Documentation
+
+- [Architecture specification](docs/architecture.md) — full spec (27 FRs, 8 NFRs)
+- [Build phases](docs/build-phases.md) — phased build plan (Phases 1-10 complete, 11-14 planned)
+- [Requirements status](docs/requirements-status.md) — tracking table for all requirements
+
 ## Development
 
 ```bash

--- a/docs/build-phases.md
+++ b/docs/build-phases.md
@@ -145,3 +145,67 @@ ductape verify --config variants/reference_project/config.yaml --expected varian
 ```
 
 If any check fails, fix it and re-run ALL checks from the top.
+
+---
+---
+
+# Future Phases
+
+The following phases address requirements not covered by Phases 1-10.
+See [requirements-status.md](requirements-status.md) for the full tracking table.
+
+---
+
+## Phase 11: Utility features (FR-10, FR-11, FR-12, FR-13, FR-14, NFR-05)
+
+1. `ductape/dependency_extractor.py` — extract headers from C/C++ package manager packages
+   into `interfaces/<version>/<source_tag>/` (FR-10)
+2. Generate `version_overview.json` listing each interface's active version number (FR-11)
+3. `ductape/version_diff.py` — diff report when `--previous-version` supplied (FR-12)
+4. Wire `WarningModule` into converter generation: emit warnings when source fields are
+   missing, graded by severity level (FR-13)
+5. Version conflict detection in `type_registry.py`: same version number with structurally
+   different layouts raises an error (FR-14)
+6. Add `--no-color` CLI flag wired to `WarningModule.use_color` (NFR-05)
+
+**Acceptance:** `ductape extract-deps` runs. `version_overview.json` generated. Missing-field
+warnings appear during generation. Duplicate version number with different layout raises error.
+
+---
+
+## Phase 12: Pluggable architecture (FR-22, FR-25)
+
+1. `ductape/frontends/frontend_base.py` — abstract `ParserFrontend` interface
+2. `ductape/frontends/c_header.py` — wrap existing `conv/parser.py` as a frontend plugin
+3. `ductape/emitters/emitter_base.py` — abstract `CodeEmitter` interface
+4. `ductape/emitters/cpp_emitter.py` — wrap existing C++ generation as an emitter plugin
+5. Config: `format: c_header` (default) selects parser; `emitter: cpp` (default) selects emitter
+
+**Acceptance:** Existing behaviour unchanged. New frontends/emitters can be added without
+modifying core engine. Tests verify plugin discovery and delegation.
+
+---
+
+## Phase 13: Additional format support (FR-23, FR-24)
+
+1. `ductape/frontends/protobuf.py` — parse `.proto` files (`message`, `enum`, `oneof`, `map`)
+   into `TypeContainer`. Track field numbers for compatibility analysis. (FR-23)
+2. `ductape/frontends/json_schema.py` — parse JSON Schema (`object`, `array`, `$ref`, `enum`)
+   into `TypeContainer`. (FR-24)
+3. `variants/reference_multi_format/` — reference project with Protobuf + C inputs
+
+**Acceptance:** Protobuf and JSON Schema files parse into TypeContainer. End-to-end generation
+works for mixed-format projects.
+
+---
+
+## Phase 14: Advanced emitters + two-stage pipelines (FR-26, FR-27)
+
+1. `ductape/emitters/shared_lib_emitter.py` — emit `.so/.dll` with stable C ABI, export
+   `GetConverterVersion()` symbol for runtime version negotiation. (FR-26)
+2. Two-stage adaptation pipeline: Stage 1 normalizes within a format family, Stage 2
+   normalizes across formats. Both configured in a single YAML file. (FR-27)
+3. `ductape diff` subcommand for structural diff between generated outputs
+
+**Acceptance:** Shared library compiles and exports expected symbols. Two-stage pipeline
+produces correct cross-format converters.

--- a/docs/requirements-status.md
+++ b/docs/requirements-status.md
@@ -1,0 +1,109 @@
+# ductape — Requirements Status
+
+Tracking document for all functional (FR) and non-functional (NFR) requirements
+from the [architecture specification](architecture.md).
+
+Last updated: 2026-03-25
+
+---
+
+## Functional Requirements
+
+### Core Engine (Phases 1-10) — COMPLETE
+
+| ID | Requirement | Status | Implementation |
+|----|-------------|--------|----------------|
+| FR-01 | Parse C struct headers without full compiler | **MET** | `conv/parser.py`, `conv/preprocessor.py` |
+| FR-02 | Multiple versions as C++ namespaces (`TypeName_V_<N>`) | **MET** | `codegen.py` generates namespaced headers |
+| FR-03 | Generic hub version (sentinel 9999 in C++) | **MET** | `data_type.py` (`GenericVersion`), `_V_Gen` namespace |
+| FR-04 | Field-level V->Generic conversion functions | **MET** | `conv/converter.py` field-by-field copy |
+| FR-05 | Default values for missing fields from config | **MET** | Config `defaults:`, applied in `converter.py` |
+| FR-06 | Array min-dimension copy | **MET** | `for (i < min(src, dst))` pattern in converter |
+| FR-07 | Field renames via config directives | **MET** | Config `renames:`, handled in `converter.py` |
+| FR-08 | Skip structurally identical converters | **MET** | `are_structurally_identical()` in `converter.py` |
+| FR-09 | Factory registration function | **MET** | `converters.cpp` with `GetGeneratedAdapters()` |
+| FR-15 | Installable as reusable Python package | **MET** | `pyproject.toml`, `pip install -e .` |
+| FR-16 | Reverse converters (Generic->V) when configured | **MET** | `generate_reverse: true` in config |
+| FR-17 | Evaluate constant integer expressions in #define | **MET** | `conv/expression_eval.py` |
+| FR-18 | Ambiguity error on fuzzy multi-match | **MET** | `AmbiguousMemberError` in `struct_pointer.py` |
+| FR-19 | C++ structs, tagged typedefs, forward decls | **MET** | `conv/parser.py` handles all variants |
+| FR-20 | Field-type compatibility checks + field_warnings | **MET** | `type_registry.py` `_check_field_compatibility()` |
+| FR-21 | `field_provenance.json` report | **MET** | `conv/field_provenance.py` |
+
+### Utility Features — NOT YET IMPLEMENTED
+
+| ID | Requirement | Status | Planned Phase |
+|----|-------------|--------|---------------|
+| FR-10 | Extract headers from package manager packages | **NOT MET** | Phase 11 |
+| FR-11 | Version overview CSV/JSON | **NOT MET** | Phase 11 |
+| FR-12 | Diff report between version snapshots | **NOT MET** | Phase 11 |
+| FR-13 | Warn (not fail) on missing source fields with severity | **PARTIAL** | Phase 11 |
+| FR-14 | Detect version conflicts (same version#, different layout) | **NOT MET** | Phase 11 |
+
+**FR-13 detail:** `WarningModule` with severity levels exists in `warnings.py`.
+Defaults are applied for missing fields. Missing: active warning emission during
+conversion generation when a source field is absent.
+
+### Pluggable Architecture — NOT YET IMPLEMENTED
+
+| ID | Requirement | Status | Planned Phase |
+|----|-------------|--------|---------------|
+| FR-22 | Pluggable parser frontends | **NOT MET** | Phase 12 |
+| FR-23 | Protobuf `.proto` parsing | **NOT MET** | Phase 13 |
+| FR-24 | JSON Schema parsing | **NOT MET** | Phase 13 |
+| FR-25 | Pluggable code emitter backends | **NOT MET** | Phase 12 |
+| FR-26 | Shared library `.so/.dll` emitter | **NOT MET** | Phase 14 |
+| FR-27 | Two-stage adaptation pipelines | **NOT MET** | Phase 14 |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement | Status | Implementation |
+|----|-------------|--------|----------------|
+| NFR-01 | Cross-platform (Win/Linux/Mac) | **MET** | Pure Python, no OS-specific logic |
+| NFR-02 | Standalone CLI (`python -m ductape`) | **MET** | `__main__.py` + `cli.py` entry point |
+| NFR-03 | Consistent 2-space C++ indentation via CodeWriter | **MET** | `conv/code_writer.py` |
+| NFR-04 | No network access during generation | **MET** | All local file I/O |
+| NFR-05 | Coloured output with `--no-color` fallback | **PARTIAL** | `WarningModule` supports color; `--no-color` CLI flag missing |
+| NFR-06 | Extensible via `variants/<project>/` folders | **MET** | Config-driven, no engine changes needed |
+| NFR-07 | YAML config with validation + actionable errors | **MET** | `config.py` with `ConfigError` |
+| NFR-08 | Golden-file regression (`--verify`) | **MET** | `ductape verify` command |
+
+---
+
+## Summary
+
+| Category | Met | Partial | Not Met | Total |
+|----------|-----|---------|---------|-------|
+| FR (Core Engine) | 16 | 0 | 0 | 16 |
+| FR (Utility) | 0 | 1 | 4 | 5 |
+| FR (Pluggable) | 0 | 0 | 6 | 6 |
+| NFR | 7 | 1 | 0 | 8 |
+| **Total** | **23** | **2** | **10** | **35** |
+
+---
+
+## Planned Future Phases
+
+### Phase 11: Utility features (FR-10, FR-11, FR-12, FR-13, FR-14)
+- `dependency_extractor.py` — extract headers from package manager packages
+- `version_overview.json` — active version numbers per type
+- `version_diff.py` — diff report between version snapshots
+- Wire `WarningModule` into converter generation for missing-field warnings
+- Version conflict detection in `type_registry.py` (same version#, different layout)
+- Add `--no-color` CLI flag (NFR-05)
+
+### Phase 12: Pluggable architecture (FR-22, FR-25)
+- `frontends/frontend_base.py` — abstract `ParserFrontend` interface
+- `frontends/c_header.py` — wrap existing parser as a frontend
+- `emitters/emitter_base.py` — abstract `CodeEmitter` interface
+- `emitters/cpp_emitter.py` — wrap existing C++ generation as an emitter
+
+### Phase 13: Additional format support (FR-23, FR-24)
+- `frontends/protobuf.py` — Protobuf `.proto` parser -> TypeContainer
+- `frontends/json_schema.py` — JSON Schema parser -> TypeContainer
+
+### Phase 14: Advanced emitters + two-stage (FR-26, FR-27)
+- `emitters/shared_lib_emitter.py` — `.so/.dll` with C ABI and `GetConverterVersion()`
+- Two-stage adaptation pipeline configuration and execution


### PR DESCRIPTION
## Summary

Complete implementation of the ductape universal schema adapter generator — a Python codegen tool that parses versioned C struct headers and generates compilable C++ converter code using a hub-and-spoke pattern.

- **All 10 build phases implemented** with 79 passing tests
- Parses 3 header versions (v1/v2/v3), generates namespaced C++ converters with field-by-field copy, renames, defaults, array min-copy, and structural identity detection
- 23 of 35 requirements met, 2 partial, 10 planned for future phases (11-14)

### Changes

- **Core engine**: preprocessor, expression evaluator, tokenizer, recursive-descent parser, type registry, converter generator, code writer, pointer abstractions, field provenance
- **CLI**: `ductape generate` and `ductape verify` subcommands
- **Reference project**: config.yaml, 3 header versions, golden expected output
- **CI**: GitHub Actions workflow (Python 3.10/3.11/3.12)
- **Docs**: Rewritten README, architecture spec moved to `docs/`, requirements tracking with future phase plan
- **Cleanup**: Removed obsolete `CLAUDE_CODE_PROMPT.md`

## Test plan

- [x] `python3 -m pytest tests/ -v` — 79/79 tests pass
- [x] `ductape generate --config variants/reference_project/config.yaml --output build/` — runs clean
- [x] `test -f build/field_provenance.json` — exists with all 3 types
- [x] `g++ -c build/converters/generated/*.cpp -Ibuild -Iruntime_reference -Ibuild/converters/generated -std=c++17` — compiles with zero errors
- [x] `ductape verify --config variants/reference_project/config.yaml --expected variants/reference_project/expected_output/` — passes

https://claude.ai/code/session_011srL1jWdiyGnoWmA3R7Nrp