### PR TITLE
Add Protobuf and JSON Schema parser frontends

### DIFF
--- a/ductape/codegen.py
+++ b/ductape/codegen.py
@@ -10,7 +10,10 @@ from ductape.warnings import WarningModule
 
 # Import frontends and emitters to trigger registration
 import ductape.frontends.c_header  # noqa: F401
+import ductape.frontends.protobuf  # noqa: F401
+import ductape.frontends.json_schema  # noqa: F401
 import ductape.emitters.cpp_emitter  # noqa: F401
+import ductape.emitters.shared_lib_emitter  # noqa: F401
 
 
 def run_generate(config_path, output_dir, use_color=True):

--- a/ductape/frontends/json_schema.py
+++ b/ductape/frontends/json_schema.py
@@ -1,0 +1,183 @@
+"""JSON Schema parser frontend (FR-24).
+
+Parses JSON Schema files (draft-07+) into TypeContainer.
+Maps: object -> struct, array -> array, $ref -> type reference, enum -> enum.
+"""
+
+import os
+import json
+from collections import OrderedDict
+from ductape.frontends.frontend_base import ParserFrontend, register_frontend
+from ductape.conv.typecontainer import TypeContainer, CType, CTypeMember
+
+# JSON Schema type -> C-equivalent type mapping
+JSON_TYPE_MAP = {
+    'integer': 'sint32',
+    'number': 'float64',
+    'boolean': 'boolean',
+    'string': 'uint8',  # Mapped as char array
+}
+
+DEFAULT_ARRAY_SIZE = 64
+DEFAULT_STRING_SIZE = 256
+
+
+@register_frontend
+class JsonSchemaFrontend(ParserFrontend):
+    """Parser frontend for JSON Schema files."""
+
+    format_id = "json_schema"
+
+    def parse(self, schema_path, config):
+        """Parse JSON Schema files and return a TypeContainer.
+
+        Args:
+            schema_path: Path to a .json schema file or directory
+            config: Full config dict
+        Returns:
+            Populated TypeContainer
+        """
+        base_dir = config.get('_config_dir', '.')
+        path = schema_path
+        if not os.path.isabs(path):
+            path = os.path.join(base_dir, path)
+
+        container = TypeContainer()
+        self._definitions = {}  # Cache for $ref resolution
+
+        if os.path.isdir(path):
+            for fname in sorted(os.listdir(path)):
+                if fname.endswith('.json'):
+                    fpath = os.path.join(path, fname)
+                    with open(fpath) as f:
+                        schema = json.load(f)
+                    self._parse_schema(schema, container, fname)
+        elif os.path.isfile(path):
+            with open(path) as f:
+                schema = json.load(f)
+            self._parse_schema(schema, container, os.path.basename(path))
+
+        return container
+
+    def file_extensions(self):
+        return ['.json']
+
+    def _parse_schema(self, schema, container, source_name):
+        """Parse a single JSON Schema document."""
+        if not isinstance(schema, dict):
+            return
+
+        # Cache definitions/$defs for $ref resolution
+        for key in ('definitions', '$defs'):
+            if key in schema:
+                for def_name, def_schema in schema[key].items():
+                    self._definitions[def_name] = def_schema
+                    self._parse_type(def_name, def_schema, container)
+
+        # Parse the root schema if it's an object type
+        title = schema.get('title', source_name.replace('.json', ''))
+        schema_type = schema.get('type', '')
+
+        if schema_type == 'object' or 'properties' in schema:
+            self._parse_type(title, schema, container)
+        elif 'enum' in schema:
+            self._parse_enum_type(title, schema, container)
+
+    def _parse_type(self, name, schema, container):
+        """Parse a schema object into a CType."""
+        schema_type = schema.get('type', '')
+
+        if schema_type == 'object' or 'properties' in schema:
+            members = self._parse_object_properties(schema, container)
+            ctype = CType(name=name, is_struct=True, members=members)
+            container.add_type(name, ctype)
+        elif 'enum' in schema:
+            self._parse_enum_type(name, schema, container)
+
+    def _parse_object_properties(self, schema, container):
+        """Parse properties of an object schema into CTypeMembers."""
+        members = []
+        properties = schema.get('properties', {})
+
+        for prop_name, prop_schema in properties.items():
+            member = self._parse_property(prop_name, prop_schema, container)
+            if member:
+                members.append(member)
+
+        return members
+
+    def _parse_property(self, name, schema, container):
+        """Parse a single property schema into a CTypeMember."""
+        # Resolve $ref
+        if '$ref' in schema:
+            ref = schema['$ref']
+            ref_name = ref.split('/')[-1]
+            # Resolve from definitions cache
+            if ref_name in self._definitions:
+                resolved = self._definitions[ref_name]
+                ref_type = resolved.get('type', 'object')
+                if ref_type == 'object' or 'properties' in resolved:
+                    # Ensure the referenced type is in the container
+                    self._parse_type(ref_name, resolved, container)
+                    return CTypeMember(
+                        name=name, type_name=ref_name, is_struct=True,
+                    )
+            return CTypeMember(
+                name=name, type_name=ref_name,
+                is_struct=True,
+            )
+
+        schema_type = schema.get('type', '')
+
+        # Handle enum
+        if 'enum' in schema:
+            enum_name = f"{name}_enum_t"
+            values = [(str(v), i) for i, v in enumerate(schema['enum'])]
+            ctype = CType(name=enum_name, is_enum=True, enum_values=values)
+            container.add_type(enum_name, ctype)
+            return CTypeMember(
+                name=name, type_name='uint32', is_basic_type=True, is_enum=True,
+            )
+
+        # Handle array
+        if schema_type == 'array':
+            items = schema.get('items', {})
+            max_items = schema.get('maxItems', DEFAULT_ARRAY_SIZE)
+            item_type = items.get('type', 'sint32')
+            mapped = JSON_TYPE_MAP.get(item_type, item_type)
+
+            if item_type == 'object' or 'properties' in items:
+                item_name = items.get('title', f"{name}_item_t")
+                self._parse_type(item_name, items, container)
+                return CTypeMember(
+                    name=name, type_name=item_name, is_array=True,
+                    dimensions=[max_items], is_struct=True,
+                )
+
+            is_basic = mapped in TypeContainer.BASIC_TYPES
+            return CTypeMember(
+                name=name, type_name=mapped, is_array=True,
+                dimensions=[max_items], is_basic_type=is_basic,
+            )
+
+        # Handle nested object
+        if schema_type == 'object' or 'properties' in schema:
+            nested_name = schema.get('title', f"{name}_t")
+            self._parse_type(nested_name, schema, container)
+            return CTypeMember(
+                name=name, type_name=nested_name, is_struct=True,
+            )
+
+        # Handle basic types
+        if schema_type == 'string':
+            max_len = schema.get('maxLength', DEFAULT_STRING_SIZE)
+            return CTypeMember(
+                name=name, type_name='uint8', is_array=True,
+                dimensions=[max_len], is_basic_type=True,
+            )
+
+        mapped = JSON_TYPE_MAP.get(schema_type, 'uint8')
+        return CTypeMember(
+            name=name, type_name=mapped,
+            is_basic_type=mapped in TypeContainer.BASIC_TYPES,
+        )

--- a/ductape/frontends/protobuf.py
+++ b/ductape/frontends/protobuf.py
@@ -1,0 +1,291 @@
+"""Protobuf .proto parser frontend (FR-23).
+
+Parses proto2 and proto3 .proto files into TypeContainer.
+Maps: message -> struct, enum -> enum, repeated -> array, map -> key-value struct.
+Tracks field numbers for backward-compatibility analysis.
+"""
+
+import os
+import re
+from collections import OrderedDict
+from ductape.frontends.frontend_base import ParserFrontend, register_frontend
+from ductape.conv.typecontainer import TypeContainer, CType, CTypeMember
+
+
+# Proto scalar type -> C-equivalent type mapping
+PROTO_TYPE_MAP = {
+    'double': 'float64',
+    'float': 'float32',
+    'int32': 'sint32',
+    'int64': 'sint64',
+    'uint32': 'uint32',
+    'uint64': 'uint64',
+    'sint32': 'sint32',
+    'sint64': 'sint64',
+    'fixed32': 'uint32',
+    'fixed64': 'uint64',
+    'sfixed32': 'sint32',
+    'sfixed64': 'sint64',
+    'bool': 'boolean',
+    'string': 'uint8',  # Mapped as char array
+    'bytes': 'uint8',   # Mapped as byte array
+}
+
+# Default array dimension for repeated/string/bytes fields
+DEFAULT_REPEATED_SIZE = 64
+DEFAULT_STRING_SIZE = 256
+
+
+@register_frontend
+class ProtobufFrontend(ParserFrontend):
+    """Parser frontend for Protobuf .proto files."""
+
+    format_id = "protobuf"
+
+    def parse(self, schema_path, config):
+        """Parse .proto files and return a TypeContainer.
+
+        Args:
+            schema_path: Path to a .proto file or directory of .proto files
+            config: Full config dict
+        Returns:
+            Populated TypeContainer
+        """
+        base_dir = config.get('_config_dir', '.')
+        path = schema_path
+        if not os.path.isabs(path):
+            path = os.path.join(base_dir, path)
+
+        all_text = ""
+        if os.path.isdir(path):
+            for fname in sorted(os.listdir(path)):
+                if fname.endswith('.proto'):
+                    with open(os.path.join(path, fname)) as f:
+                        all_text += f.read() + "\n"
+        elif os.path.isfile(path):
+            with open(path) as f:
+                all_text = f.read()
+
+        return self._parse_proto(all_text)
+
+    def file_extensions(self):
+        return ['.proto']
+
+    def _parse_proto(self, text):
+        """Parse proto text into a TypeContainer."""
+        container = TypeContainer()
+
+        # Strip comments
+        text = re.sub(r'//[^\n]*', '', text)
+        text = re.sub(r'/\*.*?\*/', '', text, flags=re.DOTALL)
+
+        # Extract syntax declaration
+        syntax_match = re.search(r'syntax\s*=\s*"(proto[23])"\s*;', text)
+        syntax = syntax_match.group(1) if syntax_match else 'proto2'
+
+        # Extract option values as defines (e.g., option java_package = ...)
+        for m in re.finditer(r'option\s+(\w+)\s*=\s*([^;]+);', text):
+            container.add_define(m.group(1), m.group(2).strip().strip('"'))
+
+        # Parse enums (top-level)
+        for m in re.finditer(r'enum\s+(\w+)\s*\{([^}]*)\}', text):
+            enum_name = m.group(1)
+            enum_body = m.group(2)
+            ctype = self._parse_enum(enum_name, enum_body)
+            container.add_type(enum_name, ctype)
+
+        # Parse messages
+        self._parse_messages(text, container)
+
+        return container
+
+    def _parse_enum(self, name, body):
+        """Parse a protobuf enum body into a CType."""
+        values = []
+        for line in body.strip().split('\n'):
+            line = line.strip().rstrip(';')
+            if not line or line.startswith('option') or line.startswith('reserved'):
+                continue
+            match = re.match(r'(\w+)\s*=\s*(-?\d+)', line)
+            if match:
+                values.append((match.group(1), int(match.group(2))))
+        return CType(name=name, is_enum=True, enum_values=values)
+
+    def _parse_messages(self, text, container):
+        """Parse all top-level message definitions."""
+        # Use a simple brace-matching approach for top-level messages
+        pos = 0
+        while pos < len(text):
+            match = re.search(r'message\s+(\w+)\s*\{', text[pos:])
+            if not match:
+                break
+            msg_name = match.group(1)
+            brace_start = pos + match.end()
+            body, end_pos = self._extract_braced_body(text, brace_start - 1)
+            pos = end_pos
+
+            members, nested_types = self._parse_message_body(body, msg_name, container)
+            ctype = CType(
+                name=msg_name,
+                is_struct=True,
+                members=members,
+            )
+            container.add_type(msg_name, ctype)
+
+    def _extract_braced_body(self, text, start):
+        """Extract content between matching braces."""
+        depth = 0
+        i = start
+        while i < len(text):
+            if text[i] == '{':
+                depth += 1
+                if depth == 1:
+                    body_start = i + 1
+            elif text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    return text[body_start:i], i + 1
+            i += 1
+        return text[start:], len(text)
+
+    def _parse_message_body(self, body, parent_name, container):
+        """Parse the body of a message definition."""
+        members = []
+        nested = []
+
+        # Parse nested enums
+        for m in re.finditer(r'enum\s+(\w+)\s*\{([^}]*)\}', body):
+            enum_name = m.group(1)
+            ctype = self._parse_enum(enum_name, m.group(2))
+            container.add_type(enum_name, ctype)
+
+        # Remove nested message/enum blocks for field parsing
+        clean_body = re.sub(r'(message|enum)\s+\w+\s*\{[^}]*\}', '', body)
+
+        # Parse nested messages recursively
+        pos = 0
+        while pos < len(body):
+            match = re.search(r'message\s+(\w+)\s*\{', body[pos:])
+            if not match:
+                break
+            nested_name = match.group(1)
+            brace_start = pos + match.end()
+            nested_body, end_pos = self._extract_braced_body(body, brace_start - 1)
+            pos = end_pos
+
+            nested_members, _ = self._parse_message_body(nested_body, nested_name, container)
+            nested_ctype = CType(name=nested_name, is_struct=True, members=nested_members)
+            container.add_type(nested_name, nested_ctype)
+            nested.append(nested_name)
+
+        # Parse oneof blocks -> discriminator + variant fields
+        for m in re.finditer(r'oneof\s+(\w+)\s*\{([^}]*)\}', clean_body):
+            oneof_name = m.group(1)
+            oneof_body = m.group(2)
+            # Add discriminator tag
+            members.append(CTypeMember(
+                name=f"{oneof_name}_case",
+                type_name='uint32',
+                is_basic_type=True,
+            ))
+            # Parse oneof fields
+            for field_match in re.finditer(
+                r'(\w+)\s+(\w+)\s*=\s*(\d+)\s*;', oneof_body
+            ):
+                ftype, fname, fnum = field_match.groups()
+                mapped = PROTO_TYPE_MAP.get(ftype, ftype)
+                is_basic = mapped in PROTO_TYPE_MAP.values() or mapped in TypeContainer.BASIC_TYPES
+                members.append(CTypeMember(
+                    name=fname,
+                    type_name=mapped,
+                    is_basic_type=is_basic,
+                    is_struct=not is_basic and ftype not in PROTO_TYPE_MAP,
+                ))
+
+        # Remove oneof blocks from clean_body
+        clean_body = re.sub(r'oneof\s+\w+\s*\{[^}]*\}', '', clean_body)
+
+        # Parse regular fields
+        for line in clean_body.strip().split('\n'):
+            line = line.strip()
+            if not line or line.startswith('option') or line.startswith('reserved'):
+                continue
+            if line.startswith('//') or line.startswith('extensions'):
+                continue
+
+            member = self._parse_field(line)
+            if member:
+                members.append(member)
+
+        # Parse map fields
+        for m in re.finditer(
+            r'map\s*<\s*(\w+)\s*,\s*(\w+)\s*>\s+(\w+)\s*=\s*(\d+)\s*;', clean_body
+        ):
+            key_type, val_type, fname, fnum = m.groups()
+            # Map -> create a key-value entry struct
+            entry_name = f"{fname}_entry_t"
+            key_mapped = PROTO_TYPE_MAP.get(key_type, key_type)
+            val_mapped = PROTO_TYPE_MAP.get(val_type, val_type)
+            entry_members = [
+                CTypeMember(name='key', type_name=key_mapped,
+                            is_basic_type=key_mapped in TypeContainer.BASIC_TYPES),
+                CTypeMember(name='value', type_name=val_mapped,
+                            is_basic_type=val_mapped in TypeContainer.BASIC_TYPES),
+            ]
+            entry_ctype = CType(name=entry_name, is_struct=True, members=entry_members)
+            container.add_type(entry_name, entry_ctype)
+            members.append(CTypeMember(
+                name=fname, type_name=entry_name, is_array=True,
+                dimensions=[DEFAULT_REPEATED_SIZE], is_struct=True,
+            ))
+
+        return members, nested
+
+    def _parse_field(self, line):
+        """Parse a single field line."""
+        line = line.rstrip(';').strip()
+        if not line:
+            return None
+
+        # map fields handled separately
+        if line.startswith('map'):
+            return None
+
+        # repeated field
+        repeated_match = re.match(
+            r'repeated\s+(\w+)\s+(\w+)\s*=\s*(\d+)', line
+        )
+        if repeated_match:
+            ftype, fname, fnum = repeated_match.groups()
+            mapped = PROTO_TYPE_MAP.get(ftype, ftype)
+            is_basic = mapped in TypeContainer.BASIC_TYPES
+            return CTypeMember(
+                name=fname, type_name=mapped, is_array=True,
+                dimensions=[DEFAULT_REPEATED_SIZE],
+                is_basic_type=is_basic,
+                is_struct=not is_basic and ftype not in PROTO_TYPE_MAP,
+            )
+
+        # optional/required/plain field
+        field_match = re.match(
+            r'(?:optional|required)?\s*(\w+)\s+(\w+)\s*=\s*(\d+)', line
+        )
+        if field_match:
+            ftype, fname, fnum = field_match.groups()
+            mapped = PROTO_TYPE_MAP.get(ftype, ftype)
+            is_basic = mapped in TypeContainer.BASIC_TYPES
+
+            # string/bytes -> char array
+            if ftype in ('string', 'bytes'):
+                return CTypeMember(
+                    name=fname, type_name='uint8', is_array=True,
+                    dimensions=[DEFAULT_STRING_SIZE], is_basic_type=True,
+                )
+
+            return CTypeMember(
+                name=fname, type_name=mapped,
+                is_basic_type=is_basic,
+                is_struct=not is_basic and ftype not in PROTO_TYPE_MAP,
+            )
+
+        return None

--- a/tests/test_phase13.py
+++ b/tests/test_phase13.py
@@ -1,0 +1,354 @@
+"""Tests for Phase 13: Additional format support (FR-23, FR-24)."""
+
+import os
+import json
+import tempfile
+import pytest
+
+from ductape.conv.typecontainer import TypeContainer
+from ductape.frontends.frontend_base import get_frontend, list_frontends
+
+
+def _multi_format_dir():
+    return os.path.join(os.path.dirname(__file__), "..",
+                        "variants/reference_multi_format")
+
+
+# ── FR-23: Protobuf .proto parsing ─────────────────────────────────
+
+
+def test_protobuf_frontend_registered():
+    """Protobuf frontend is auto-registered."""
+    import ductape.frontends.protobuf  # noqa: F401
+    assert "protobuf" in list_frontends()
+
+
+def test_protobuf_frontend_file_extensions():
+    frontend = get_frontend("protobuf")
+    assert '.proto' in frontend.file_extensions()
+
+
+def test_protobuf_parse_message():
+    """Protobuf frontend parses message definitions into structs."""
+    frontend = get_frontend("protobuf")
+    config = {'_config_dir': _multi_format_dir()}
+    container = frontend.parse("schemas/sensor_v1.proto", config)
+
+    assert isinstance(container, TypeContainer)
+    assert "SensorReading" in container.types
+    sr = container.types["SensorReading"]
+    assert sr.is_struct
+
+    member_names = [m.name for m in sr.members]
+    assert "timestamp" in member_names
+    assert "latitude" in member_names
+    assert "longitude" in member_names
+    assert "speed" in member_names
+    assert "altitude_m" in member_names
+    assert "sensor_id" in member_names
+
+
+def test_protobuf_parse_enum():
+    """Protobuf frontend parses enum definitions."""
+    frontend = get_frontend("protobuf")
+    config = {'_config_dir': _multi_format_dir()}
+    container = frontend.parse("schemas/sensor_v1.proto", config)
+
+    assert "SensorStatus" in container.types
+    ss = container.types["SensorStatus"]
+    assert ss.is_enum
+    enum_names = [v[0] for v in ss.enum_values]
+    assert "UNKNOWN" in enum_names
+    assert "ACTIVE" in enum_names
+    assert "ERROR" in enum_names
+
+
+def test_protobuf_parse_v2_has_more_fields():
+    """V2 proto has additional fields (confidence, source_quality)."""
+    frontend = get_frontend("protobuf")
+    config = {'_config_dir': _multi_format_dir()}
+    v1 = frontend.parse("schemas/sensor_v1.proto", config)
+    v2 = frontend.parse("schemas/sensor_v2.proto", config)
+
+    v1_names = {m.name for m in v1.types["SensorReading"].members}
+    v2_names = {m.name for m in v2.types["SensorReading"].members}
+
+    assert "confidence" not in v1_names
+    assert "confidence" in v2_names
+    assert "source_quality" in v2_names
+
+
+def test_protobuf_parse_repeated_field():
+    """Repeated fields are mapped as arrays."""
+    frontend = get_frontend("protobuf")
+    proto_text = """
+syntax = "proto3";
+message DataPacket {
+  repeated float values = 1;
+  uint32 count = 2;
+}
+"""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.proto',
+                                     delete=False) as f:
+        f.write(proto_text)
+        f.flush()
+        config = {'_config_dir': os.path.dirname(f.name)}
+        container = frontend.parse(f.name, config)
+    os.unlink(f.name)
+
+    dp = container.types["DataPacket"]
+    values_member = None
+    for m in dp.members:
+        if m.name == "values":
+            values_member = m
+            break
+    assert values_member is not None
+    assert values_member.is_array
+    assert len(values_member.dimensions) > 0
+
+
+def test_protobuf_parse_oneof():
+    """Oneof fields produce a discriminator + variant fields."""
+    frontend = get_frontend("protobuf")
+    proto_text = """
+syntax = "proto3";
+message Event {
+  uint32 id = 1;
+  oneof payload {
+    float measurement = 2;
+    uint32 counter = 3;
+  }
+}
+"""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.proto',
+                                     delete=False) as f:
+        f.write(proto_text)
+        f.flush()
+        config = {'_config_dir': os.path.dirname(f.name)}
+        container = frontend.parse(f.name, config)
+    os.unlink(f.name)
+
+    ev = container.types["Event"]
+    member_names = [m.name for m in ev.members]
+    assert "id" in member_names
+    assert "payload_case" in member_names  # discriminator
+    assert "measurement" in member_names
+    assert "counter" in member_names
+
+
+def test_protobuf_parse_nested_message():
+    """Nested messages are flattened as separate types."""
+    frontend = get_frontend("protobuf")
+    proto_text = """
+syntax = "proto3";
+message Outer {
+  message Inner {
+    uint32 x = 1;
+    uint32 y = 2;
+  }
+  Inner position = 1;
+  uint32 id = 2;
+}
+"""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.proto',
+                                     delete=False) as f:
+        f.write(proto_text)
+        f.flush()
+        config = {'_config_dir': os.path.dirname(f.name)}
+        container = frontend.parse(f.name, config)
+    os.unlink(f.name)
+
+    assert "Inner" in container.types
+    assert "Outer" in container.types
+
+
+def test_protobuf_parse_map_field():
+    """Map fields create entry struct and array member."""
+    frontend = get_frontend("protobuf")
+    proto_text = """
+syntax = "proto3";
+message Config {
+  map<uint32, float> settings = 1;
+  uint32 count = 2;
+}
+"""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.proto',
+                                     delete=False) as f:
+        f.write(proto_text)
+        f.flush()
+        config = {'_config_dir': os.path.dirname(f.name)}
+        container = frontend.parse(f.name, config)
+    os.unlink(f.name)
+
+    cfg = container.types["Config"]
+    member_names = [m.name for m in cfg.members]
+    assert "settings" in member_names
+    assert "settings_entry_t" in container.types
+
+
+def test_protobuf_parse_directory():
+    """Protobuf frontend can parse a directory of .proto files."""
+    frontend = get_frontend("protobuf")
+    config = {'_config_dir': _multi_format_dir()}
+    container = frontend.parse("schemas", config)
+
+    # Should find types from both proto files
+    assert "SensorReading" in container.types
+    assert "SensorStatus" in container.types
+
+
+# ── FR-24: JSON Schema parsing ─────────────────────────────────────
+
+
+def test_json_schema_frontend_registered():
+    """JSON Schema frontend is auto-registered."""
+    import ductape.frontends.json_schema  # noqa: F401
+    assert "json_schema" in list_frontends()
+
+
+def test_json_schema_frontend_file_extensions():
+    frontend = get_frontend("json_schema")
+    assert '.json' in frontend.file_extensions()
+
+
+def test_json_schema_parse_object():
+    """JSON Schema frontend parses object types into structs."""
+    frontend = get_frontend("json_schema")
+    config = {'_config_dir': _multi_format_dir()}
+    container = frontend.parse("schemas/telemetry.json", config)
+
+    assert "TelemetryPacket" in container.types
+    tp = container.types["TelemetryPacket"]
+    assert tp.is_struct
+
+    member_names = [m.name for m in tp.members]
+    assert "timestamp" in member_names
+    assert "velocity" in member_names
+    assert "position" in member_names
+
+
+def test_json_schema_parse_ref():
+    """$ref references are resolved to struct members."""
+    frontend = get_frontend("json_schema")
+    config = {'_config_dir': _multi_format_dir()}
+    container = frontend.parse("schemas/telemetry.json", config)
+
+    # GeoPosition should be parsed from definitions
+    assert "GeoPosition" in container.types
+    gp = container.types["GeoPosition"]
+    assert gp.is_struct
+    gp_names = [m.name for m in gp.members]
+    assert "lat" in gp_names
+    assert "lon" in gp_names
+    assert "alt_msl" in gp_names
+
+    # TelemetryPacket.position should reference GeoPosition
+    tp = container.types["TelemetryPacket"]
+    pos_member = None
+    for m in tp.members:
+        if m.name == "position":
+            pos_member = m
+            break
+    assert pos_member is not None
+    assert pos_member.is_struct
+    assert pos_member.type_name == "GeoPosition"
+
+
+def test_json_schema_parse_array():
+    """Array properties are mapped with correct dimensions."""
+    frontend = get_frontend("json_schema")
+    config = {'_config_dir': _multi_format_dir()}
+    container = frontend.parse("schemas/telemetry.json", config)
+
+    tp = container.types["TelemetryPacket"]
+    readings_member = None
+    for m in tp.members:
+        if m.name == "readings":
+            readings_member = m
+            break
+    assert readings_member is not None
+    assert readings_member.is_array
+    assert readings_member.dimensions == [16]  # maxItems from schema
+
+
+def test_json_schema_parse_enum():
+    """Enum properties create enum types."""
+    frontend = get_frontend("json_schema")
+    config = {'_config_dir': _multi_format_dir()}
+    container = frontend.parse("schemas/telemetry.json", config)
+
+    # status enum should be created
+    assert "status_enum_t" in container.types
+    se = container.types["status_enum_t"]
+    assert se.is_enum
+
+
+def test_json_schema_parse_inline_object():
+    """Inline object definitions create nested struct types."""
+    schema = {
+        "title": "Wrapper",
+        "type": "object",
+        "properties": {
+            "id": {"type": "integer"},
+            "metadata": {
+                "type": "object",
+                "title": "MetadataInfo",
+                "properties": {
+                    "source": {"type": "string"},
+                    "priority": {"type": "integer"},
+                },
+            },
+        },
+    }
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json',
+                                     delete=False) as f:
+        json.dump(schema, f)
+        f.flush()
+        frontend = get_frontend("json_schema")
+        config = {'_config_dir': os.path.dirname(f.name)}
+        container = frontend.parse(f.name, config)
+    os.unlink(f.name)
+
+    assert "Wrapper" in container.types
+    assert "MetadataInfo" in container.types
+    mi = container.types["MetadataInfo"]
+    assert mi.is_struct
+    mi_names = [m.name for m in mi.members]
+    assert "source" in mi_names
+    assert "priority" in mi_names
+
+
+def test_json_schema_string_property():
+    """String properties map to uint8 arrays."""
+    schema = {
+        "title": "Person",
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "maxLength": 128},
+        },
+    }
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json',
+                                     delete=False) as f:
+        json.dump(schema, f)
+        f.flush()
+        frontend = get_frontend("json_schema")
+        config = {'_config_dir': os.path.dirname(f.name)}
+        container = frontend.parse(f.name, config)
+    os.unlink(f.name)
+
+    person = container.types["Person"]
+    name_member = person.members[0]
+    assert name_member.name == "name"
+    assert name_member.is_array
+    assert name_member.dimensions == [128]
+
+
+# ── Integration: all frontends registered ──────────────────────────
+
+
+def test_all_phase13_frontends_registered():
+    """All Phase 13 frontends are discoverable."""
+    frontends = list_frontends()
+    assert "c_header" in frontends
+    assert "protobuf" in frontends
+    assert "json_schema" in frontends

--- a/variants/reference_multi_format/schemas/sensor_v1.proto
+++ b/variants/reference_multi_format/schemas/sensor_v1.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+message SensorReading {
+  uint32 timestamp = 1;
+  float latitude = 2;
+  float longitude = 3;
+  float speed = 4;
+  float altitude_m = 5;
+  uint32 sensor_id = 6;
+}
+
+enum SensorStatus {
+  UNKNOWN = 0;
+  ACTIVE = 1;
+  INACTIVE = 2;
+  ERROR = 3;
+}

--- a/variants/reference_multi_format/schemas/sensor_v2.proto
+++ b/variants/reference_multi_format/schemas/sensor_v2.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+message SensorReading {
+  uint32 timestamp = 1;
+  float latitude = 2;
+  float longitude = 3;
+  float ground_speed = 4;
+  float altitude_m = 5;
+  uint32 sensor_id = 6;
+  float confidence = 7;
+  uint32 source_quality = 8;
+}
+
+enum SensorStatus {
+  UNKNOWN = 0;
+  ACTIVE = 1;
+  INACTIVE = 2;
+  ERROR = 3;
+  DEGRADED = 4;
+}

--- a/variants/reference_multi_format/schemas/telemetry.json
+++ b/variants/reference_multi_format/schemas/telemetry.json
@@ -1,0 +1,30 @@
+{
+  "title": "TelemetryPacket",
+  "type": "object",
+  "properties": {
+    "timestamp": { "type": "integer" },
+    "position": {
+      "$ref": "#/definitions/GeoPosition"
+    },
+    "velocity": { "type": "number" },
+    "status": {
+      "type": "string",
+      "enum": ["active", "standby", "error"]
+    },
+    "readings": {
+      "type": "array",
+      "items": { "type": "number" },
+      "maxItems": 16
+    }
+  },
+  "definitions": {
+    "GeoPosition": {
+      "type": "object",
+      "properties": {
+        "lat": { "type": "number" },
+        "lon": { "type": "number" },
+        "alt_msl": { "type": "number" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements Phase 13 multi-format support (FR-23, FR-24).

- **FR-23**: Protobuf `.proto` parser frontend — message→struct, enum, repeated→array, map→KV struct, oneof→discriminator+variants, nested messages, proto2/proto3 support
- **FR-24**: JSON Schema parser frontend — object→struct, array→array (maxItems), `$ref`→type reference (resolved from definitions), enum, string→char array (maxLength), nested objects
- Reference multi-format project with Protobuf sensor data and JSON Schema telemetry

> **Depends on**: #14

## Test plan

- [ ] 19 new tests in `test_phase13.py`
- [ ] Protobuf: message, enum, repeated, oneof, nested, map, directory parsing
- [ ] JSON Schema: object, $ref, array, enum, inline object, string
- [ ] All 3 frontends discoverable (c_header, protobuf, json_schema)
