### PR TITLE
Add shared library emitter and two-stage adaptation pipeline

### DIFF
--- a/ductape/cli.py
+++ b/ductape/cli.py
@@ -31,6 +31,13 @@ def main():
     diff_parser.add_argument("--current", required=True,
                              help="Path to current version_overview.json")
 
+    struct_diff_parser = subparsers.add_parser("struct-diff",
+                                                help="Structural diff between generated outputs")
+    struct_diff_parser.add_argument("--dir1", required=True,
+                                    help="First generated output directory")
+    struct_diff_parser.add_argument("--dir2", required=True,
+                                    help="Second generated output directory")
+
     args = parser.parse_args()
 
     use_color = not args.no_color
@@ -56,3 +63,6 @@ def main():
         from ductape.version_diff import generate_diff_report, format_diff_report
         diff = generate_diff_report(args.previous, args.current)
         print(format_diff_report(diff))
+    elif args.command == "struct-diff":
+        from ductape.struct_diff import run_struct_diff
+        run_struct_diff(args.dir1, args.dir2)

--- a/ductape/emitters/shared_lib_emitter.py
+++ b/ductape/emitters/shared_lib_emitter.py
@@ -1,0 +1,303 @@
+"""Shared library emitter (FR-26).
+
+Emits C source code with a stable C ABI that compiles into a .so/.dll.
+Exports: GetConverterVersion(), ConvertData(), GetSupportedVersions().
+Loadable at runtime via dlopen/LoadLibrary without process restart.
+"""
+
+import os
+from ductape.emitters.emitter_base import CodeEmitter, register_emitter
+from ductape.conv.code_writer import CodeWriter
+from ductape.conv.converter import Converter
+
+
+@register_emitter
+class SharedLibEmitter(CodeEmitter):
+    """Shared library (.so/.dll) emitter with stable C ABI."""
+
+    emitter_id = "shared_lib"
+
+    def emit_type_header(self, data_type, output_dir, registry=None):
+        """Emit C-compatible type definitions header."""
+        dt = data_type
+        sentinel = dt.generic.version if dt.generic else 9999
+
+        w = CodeWriter()
+        w.line("#pragma once")
+        w.line("#include <stdint.h>")
+        w.line("#include <string.h>")
+        w.line()
+
+        w.line("/* Type definitions for all versions */")
+        w.line()
+
+        # Emit dependent struct types first (e.g. BatteryInfo_t)
+        emitted_deps = set()
+        all_dtvs = [dt.versions[v] for v in sorted(dt.versions.keys())]
+        if dt.generic:
+            all_dtvs.append(dt.generic)
+        for dtv in all_dtvs:
+            self._emit_dependent_structs(w, dtv, dt.name, emitted_deps, registry)
+
+        for ver_num in sorted(dt.versions.keys()):
+            dtv = dt.versions[ver_num]
+            self._emit_c_struct(w, dt.name, dtv, f"v{ver_num}")
+
+        if dt.generic:
+            self._emit_c_struct(w, dt.name, dt.generic, "generic")
+
+        filepath = os.path.join(output_dir, "shared_lib", f"{dt.name}_types.h")
+        w.write_to(filepath)
+
+    def emit_converter(self, data_type, config, output_dir, warning_module=None):
+        """Emit C-ABI converter source file."""
+        dt = data_type
+        conv = Converter(dt, config, warning_module=warning_module)
+        sentinel = dt.generic.version if dt.generic else 9999
+
+        w = CodeWriter()
+        w.line(f'#include "{dt.name}_types.h"')
+        w.line()
+
+        # Version query function
+        w.line(f"/* Exported C ABI functions for {dt.name} */")
+        w.line()
+        w.line("#ifdef _WIN32")
+        w.line("#define EXPORT __declspec(dllexport)")
+        w.line("#else")
+        w.line("#define EXPORT __attribute__((visibility(\"default\")))")
+        w.line("#endif")
+        w.line()
+
+        # GetConverterVersion
+        w.line(f"EXPORT uint32_t {dt.name}_GetConverterVersion(void)")
+        w.block_open()
+        w.line("return 1; /* Converter ABI version */")
+        w.block_close()
+        w.line()
+
+        # GetSupportedVersions
+        versions = sorted(dt.versions.keys())
+        w.line(f"static const uint32_t {dt.name}_supported_versions[] = {{")
+        w.indent()
+        w.line(", ".join(str(v) for v in versions))
+        w.dedent()
+        w.line("};")
+        w.line()
+        w.line(f"EXPORT uint32_t {dt.name}_GetSupportedVersionCount(void)")
+        w.block_open()
+        w.line(f"return {len(versions)};")
+        w.block_close()
+        w.line()
+        w.line(f"EXPORT const uint32_t* {dt.name}_GetSupportedVersions(void)")
+        w.block_open()
+        w.line(f"return {dt.name}_supported_versions;")
+        w.block_close()
+        w.line()
+
+        # Forward conversion functions per version
+        for ver_num in sorted(dt.versions.keys()):
+            dtv = dt.versions[ver_num]
+            if conv.are_structurally_identical(dtv, dt.generic):
+                continue
+            v_prefix = f"{dt.name}_v{ver_num}"
+            g_prefix = f"{dt.name}_generic"
+            w.line(f"static void convert_{v_prefix}_to_generic(")
+            w.indent()
+            w.line(f"struct {g_prefix}* dest,")
+            w.line(f"const struct {v_prefix}* source)")
+            w.dedent()
+            w.block_open()
+            w.line("memset(dest, 0, sizeof(*dest));")
+            self._emit_field_copies(w, dtv, dt.generic, conv, dt)
+            w.block_close()
+            w.line()
+
+        # Reverse conversion functions
+        if dt.generate_reverse:
+            for ver_num in sorted(dt.versions.keys()):
+                dtv = dt.versions[ver_num]
+                if conv.are_structurally_identical(dtv, dt.generic):
+                    continue
+                v_prefix = f"{dt.name}_v{ver_num}"
+                g_prefix = f"{dt.name}_generic"
+                w.line(f"static void convert_generic_to_{v_prefix}(")
+                w.indent()
+                w.line(f"struct {v_prefix}* dest,")
+                w.line(f"const struct {g_prefix}* source)")
+                w.dedent()
+                w.block_open()
+                w.line("memset(dest, 0, sizeof(*dest));")
+                self._emit_field_copies(w, dt.generic, dtv, conv, dt)
+                w.block_close()
+                w.line()
+
+        # ConvertData dispatcher
+        w.line(f"EXPORT int {dt.name}_ConvertData(")
+        w.indent()
+        w.line("uint32_t src_version,")
+        w.line("const void* src_data,")
+        w.line("void* dst_data,")
+        w.line("uint32_t dst_size)")
+        w.dedent()
+        w.block_open()
+        w.line(f"struct {dt.name}_generic* generic = (struct {dt.name}_generic*)dst_data;")
+        w.line("switch (src_version)")
+        w.block_open()
+        for ver_num in sorted(dt.versions.keys()):
+            dtv = dt.versions[ver_num]
+            v_prefix = f"{dt.name}_v{ver_num}"
+            w.line(f"case {ver_num}:")
+            w.indent()
+            if conv.are_structurally_identical(dtv, dt.generic):
+                w.line(f"memcpy(generic, src_data, sizeof(*generic));")
+            else:
+                w.line(f"convert_{v_prefix}_to_generic(generic, (const struct {v_prefix}*)src_data);")
+            w.line("return 0;")
+            w.dedent()
+        w.line("default:")
+        w.indent()
+        w.line("return -1;")
+        w.dedent()
+        w.block_close()
+        w.block_close()
+        w.line()
+
+        filepath = os.path.join(output_dir, "shared_lib", f"{dt.name}_converter.c")
+        w.write_to(filepath)
+
+    def emit_factory(self, data_types, output_dir):
+        """Emit shared library factory registration header."""
+        w = CodeWriter()
+        w.line("#pragma once")
+        w.line("#include <stdint.h>")
+        w.line()
+        w.line("#ifdef _WIN32")
+        w.line("#define EXPORT __declspec(dllexport)")
+        w.line("#else")
+        w.line("#define EXPORT __attribute__((visibility(\"default\")))")
+        w.line("#endif")
+        w.line()
+
+        for name in sorted(data_types.keys()):
+            w.line(f"/* {name} exports */")
+            w.line(f"EXPORT uint32_t {name}_GetConverterVersion(void);")
+            w.line(f"EXPORT uint32_t {name}_GetSupportedVersionCount(void);")
+            w.line(f"EXPORT const uint32_t* {name}_GetSupportedVersions(void);")
+            w.line(f"EXPORT int {name}_ConvertData(")
+            w.indent()
+            w.line("uint32_t src_version, const void* src_data,")
+            w.line("void* dst_data, uint32_t dst_size);")
+            w.dedent()
+            w.line()
+
+        filepath = os.path.join(output_dir, "shared_lib", "adapter_exports.h")
+        w.write_to(filepath)
+
+    # ── Private helpers ────────────────────────────────────────────
+
+    def _emit_dependent_structs(self, w, dtv, parent_name, emitted, registry):
+        """Emit C structs for dependent types (e.g. BatteryInfo_t)."""
+        if registry is None:
+            return
+        for member in dtv.ctype.members:
+            tname = member.type_name
+            if tname == parent_name or tname in emitted:
+                continue
+            if not member.is_struct:
+                continue
+            # Find struct definition in registry
+            struct_def = None
+            for iv in registry.interface_versions:
+                if tname in iv.container.types:
+                    ct = iv.container.types[tname]
+                    if ct.is_struct:
+                        struct_def = ct
+                        break
+            if struct_def:
+                emitted.add(tname)
+                w.line(f"struct {tname}")
+                w.block_open()
+                for sm in struct_def.members:
+                    dim_str = ''.join(f'[{d}]' for d in sm.dimensions)
+                    c_type = self._cpp_to_c_type(sm.type_name)
+                    w.line(f"{c_type} {sm.name}{dim_str};")
+                w.block_close(";")
+                w.line()
+
+    def _emit_c_struct(self, w, type_name, dtv, version_label):
+        """Emit a plain C struct for a version."""
+        struct_name = f"{type_name}_{version_label}"
+        w.line(f"struct {struct_name}")
+        w.block_open()
+        for member in dtv.ctype.members:
+            dim_str = ''.join(f'[{d}]' for d in member.dimensions)
+            if member.is_struct:
+                w.line(f"struct {member.type_name} {member.name}{dim_str};")
+            else:
+                c_type = self._cpp_to_c_type(member.type_name)
+                w.line(f"{c_type} {member.name}{dim_str};")
+        w.block_close(";")
+        w.line()
+
+    def _cpp_to_c_type(self, type_name):
+        """Map platform types to C stdint types."""
+        mapping = {
+            'uint8': 'uint8_t', 'sint8': 'int8_t',
+            'uint16': 'uint16_t', 'sint16': 'int16_t',
+            'uint32': 'uint32_t', 'sint32': 'int32_t',
+            'uint64': 'uint64_t', 'sint64': 'int64_t',
+            'float32': 'float', 'float64': 'double',
+            'boolean': 'uint8_t',
+        }
+        return mapping.get(type_name, type_name)
+
+    def _emit_field_copies(self, w, src_dtv, dst_dtv, conv, dt):
+        """Emit field-by-field copy in C style."""
+        renames = dt.renames
+        reverse_renames = {v: k for k, v in renames.items()}
+        defaults = dt.defaults
+
+        for dst_member in dst_dtv.ctype.members:
+            dst_name = dst_member.name
+            # Find source field name
+            src_name = self._find_src_field(dst_name, src_dtv, renames, reverse_renames)
+
+            if src_name is not None:
+                src_member = None
+                for m in src_dtv.ctype.members:
+                    if m.name == src_name:
+                        src_member = m
+                        break
+                if src_member and src_member.is_array and dst_member.is_array:
+                    src_dim = src_member.dimensions[0] if src_member.dimensions else 0
+                    dst_dim = dst_member.dimensions[0] if dst_member.dimensions else 0
+                    if src_dim == dst_dim:
+                        min_dim = str(src_dim)
+                    else:
+                        min_dim = f"({src_dim} < {dst_dim} ? {src_dim} : {dst_dim})"
+                    w.line(f"for (int i = 0; i < {min_dim}; i++)")
+                    w.indent()
+                    w.line(f"dest->{dst_name}[i] = source->{src_name}[i];")
+                    w.dedent()
+                elif src_member and src_member.is_struct:
+                    w.line(f"memcpy(&dest->{dst_name}, &source->{src_name}, sizeof(dest->{dst_name}));")
+                else:
+                    w.line(f"dest->{dst_name} = source->{src_name};")
+            else:
+                default_val = defaults.get(dst_name)
+                if default_val is not None and not dst_member.is_struct:
+                    w.line(f"dest->{dst_name} = {default_val};")
+                else:
+                    w.line(f"/* {dst_name}: not in source, zero from memset */")
+
+    def _find_src_field(self, dst_name, src_dtv, renames, reverse_renames):
+        for m in src_dtv.ctype.members:
+            if m.name == dst_name:
+                return dst_name
+        old_name = reverse_renames.get(dst_name)
+        if old_name:
+            for m in src_dtv.ctype.members:
+                if m.name == old_name:
+                    return old_name
+        return None

--- a/ductape/struct_diff.py
+++ b/ductape/struct_diff.py
@@ -1,0 +1,92 @@
+"""Structural diff between generated outputs (Phase 14).
+
+Compares two generated output directories and reports structural
+differences in type definitions and converter files.
+"""
+
+import os
+import filecmp
+
+
+def compute_struct_diff(dir1, dir2):
+    """Compare two generated output directories structurally.
+
+    Args:
+        dir1: First output directory
+        dir2: Second output directory
+    Returns:
+        dict with 'only_in_dir1', 'only_in_dir2', 'differing', 'identical'
+    """
+    files1 = _collect_files(dir1)
+    files2 = _collect_files(dir2)
+
+    set1 = set(files1.keys())
+    set2 = set(files2.keys())
+
+    only_in_dir1 = sorted(set1 - set2)
+    only_in_dir2 = sorted(set2 - set1)
+
+    differing = []
+    identical = []
+    for rel_path in sorted(set1 & set2):
+        if filecmp.cmp(files1[rel_path], files2[rel_path], shallow=False):
+            identical.append(rel_path)
+        else:
+            differing.append(rel_path)
+
+    return {
+        'only_in_dir1': only_in_dir1,
+        'only_in_dir2': only_in_dir2,
+        'differing': differing,
+        'identical': identical,
+    }
+
+
+def format_struct_diff(diff, dir1, dir2):
+    """Format a structural diff as human-readable text."""
+    lines = [
+        "Structural Diff Report",
+        "=" * 50,
+        f"  Dir 1: {dir1}",
+        f"  Dir 2: {dir2}",
+        "",
+    ]
+
+    if diff['only_in_dir1']:
+        lines.append(f"Only in dir1 ({len(diff['only_in_dir1'])} files):")
+        for f in diff['only_in_dir1']:
+            lines.append(f"  - {f}")
+
+    if diff['only_in_dir2']:
+        lines.append(f"\nOnly in dir2 ({len(diff['only_in_dir2'])} files):")
+        for f in diff['only_in_dir2']:
+            lines.append(f"  + {f}")
+
+    if diff['differing']:
+        lines.append(f"\nDiffering ({len(diff['differing'])} files):")
+        for f in diff['differing']:
+            lines.append(f"  ~ {f}")
+
+    lines.append(f"\nIdentical: {len(diff['identical'])} files")
+
+    if not diff['only_in_dir1'] and not diff['only_in_dir2'] and not diff['differing']:
+        lines.append("\nDirectories are structurally identical.")
+
+    return '\n'.join(lines)
+
+
+def run_struct_diff(dir1, dir2):
+    """Run structural diff and print results."""
+    diff = compute_struct_diff(dir1, dir2)
+    print(format_struct_diff(diff, dir1, dir2))
+
+
+def _collect_files(root_dir):
+    """Collect all files with relative paths."""
+    files = {}
+    for dirpath, _, filenames in os.walk(root_dir):
+        for fname in filenames:
+            full_path = os.path.join(dirpath, fname)
+            rel_path = os.path.relpath(full_path, root_dir)
+            files[rel_path] = full_path
+    return files

--- a/ductape/two_stage.py
+++ b/ductape/two_stage.py
@@ -1,0 +1,225 @@
+"""Two-stage adaptation pipeline (FR-27).
+
+Stage 1: Intra-format versioning — normalizes within a format family
+         (e.g. Protobuf V1/V2/V3 -> Protobuf canonical).
+Stage 2: Cross-format normalization — maps between format families
+         (e.g. Protobuf canonical -> C struct canonical).
+
+Both stages use the same hub-and-spoke engine. Field mapping, default
+injection, rename handling, and provenance tracking are identical.
+"""
+
+import os
+import json
+from dataclasses import dataclass, field
+from typing import Optional
+
+from ductape.conv.typecontainer import TypeContainer, CType, CTypeMember
+from ductape.conv.data_type import DataType
+from ductape.conv.data_type_version import DataTypeVersion
+from ductape.conv.converter import Converter
+from ductape.conv.code_writer import CodeWriter
+from ductape.warnings import WarningModule
+
+
+@dataclass
+class StageResult:
+    """Result from a pipeline stage."""
+    data_types: dict = field(default_factory=dict)  # name -> DataType
+    containers: list = field(default_factory=list)   # list of TypeContainer
+
+
+@dataclass
+class FieldMapping:
+    """A single field mapping from source to target."""
+    source_field: str
+    target_field: str
+
+
+class TwoStagePipeline:
+    """Orchestrates two-stage adaptation from heterogeneous sources."""
+
+    def __init__(self, pipeline_config, warning_module=None):
+        """Initialize pipeline from config.
+
+        Args:
+            pipeline_config: dict with 'sources' key containing stage definitions
+            warning_module: optional WarningModule for diagnostics
+        """
+        self.config = pipeline_config
+        self.warning_module = warning_module or WarningModule(use_color=False)
+        self.stage1_results = {}  # source_name -> StageResult
+        self.stage2_result = None
+
+    def run_stage1(self, source_name, source_config, containers):
+        """Run Stage 1: intra-format versioning for one source.
+
+        Builds DataType objects from parsed containers, creates generic
+        hub version, and produces converters within the format family.
+
+        Args:
+            source_name: identifier for this source
+            source_config: dict with stage1 config (hub_version, types, etc.)
+            containers: list of (version_tag, TypeContainer) tuples
+        Returns:
+            StageResult with fully resolved data types
+        """
+        stage1_cfg = source_config.get('stage1', {})
+        types_cfg = stage1_cfg.get('types', {})
+        sentinel = 9999
+
+        result = StageResult()
+
+        for type_name, type_cfg in types_cfg.items():
+            dt = DataType(
+                name=type_name,
+                version_macro=type_cfg.get('version_field', f'{type_name}_VERSION'),
+                defaults=type_cfg.get('defaults', {}),
+                renames=type_cfg.get('renames', {}),
+                field_warnings=type_cfg.get('field_warnings', {}),
+                generate_reverse=type_cfg.get('generate_reverse', False),
+            )
+
+            # Register versions from containers
+            for ver_idx, (version_tag, container) in enumerate(containers):
+                ver_num = ver_idx + 1
+                if type_name in container.types:
+                    dt.add_version(ver_num, container.types[type_name])
+
+            # Build generic
+            dt.build_generic(sentinel)
+            result.data_types[type_name] = dt
+
+        result.containers = [c for _, c in containers]
+        self.stage1_results[source_name] = result
+        return result
+
+    def run_stage2(self, stage2_config, stage1_results):
+        """Run Stage 2: cross-format normalization.
+
+        Maps fields from stage1 canonical types to target types using
+        configured field mappings.
+
+        Args:
+            stage2_config: dict with type_mappings and field_mappings
+            stage1_results: dict of source_name -> StageResult
+        Returns:
+            StageResult with cross-format mapped types
+        """
+        type_mappings = stage2_config.get('type_mappings', {})
+        field_mappings = stage2_config.get('field_mappings', {})
+
+        result = StageResult()
+
+        for src_type, dst_type in type_mappings.items():
+            # Find the source DataType from any stage1 result
+            src_dt = None
+            for src_name, sr in stage1_results.items():
+                if src_type in sr.data_types:
+                    src_dt = sr.data_types[src_type]
+                    break
+
+            if src_dt is None or src_dt.generic is None:
+                if self.warning_module:
+                    self.warning_module.add(
+                        f"Stage 2: source type '{src_type}' not found in any stage 1 result",
+                        severity=2, context="two_stage"
+                    )
+                continue
+
+            # Build mapped type from generic
+            mappings = field_mappings.get(src_type, {})
+            mapped_members = []
+
+            for member in src_dt.generic.ctype.members:
+                target_field = mappings.get(member.name, member.name)
+                mapped_members.append(CTypeMember(
+                    name=target_field,
+                    type_name=member.type_name,
+                    is_array=member.is_array,
+                    dimensions=list(member.dimensions),
+                    is_struct=member.is_struct,
+                    is_enum=member.is_enum,
+                    is_basic_type=member.is_basic_type,
+                ))
+
+            mapped_ctype = CType(
+                name=dst_type, is_struct=True, members=mapped_members,
+            )
+            mapped_dtv = DataTypeVersion(
+                type_name=dst_type, version=9999, ctype=mapped_ctype,
+                namespace=f"{dst_type}_V_Gen",
+            )
+
+            # Create a DataType for the mapped output
+            dt = DataType(
+                name=dst_type,
+                version_macro=f"{dst_type}_VERSION",
+            )
+            # The mapped type has a single "version" which is the cross-format result
+            dt.generic = mapped_dtv
+            # Copy the source versions as the input versions
+            for ver_num, src_dtv in src_dt.versions.items():
+                dt.add_version(ver_num, src_dtv.ctype)
+
+            result.data_types[dst_type] = dt
+
+        self.stage2_result = result
+        return result
+
+    def run(self, parsed_sources):
+        """Run the full two-stage pipeline.
+
+        Args:
+            parsed_sources: dict of source_name -> {
+                'config': source config dict,
+                'containers': list of (version_tag, TypeContainer),
+            }
+        Returns:
+            dict with 'stage1' and 'stage2' results
+        """
+        sources_config = self.config.get('sources', {})
+
+        # Stage 1: process each source independently
+        for source_name, source_data in parsed_sources.items():
+            source_cfg = sources_config.get(source_name, source_data.get('config', {}))
+            self.run_stage1(
+                source_name, source_cfg, source_data['containers']
+            )
+
+        # Stage 2: cross-format mapping
+        stage2_config = self.config.get('stage2', {})
+        if stage2_config:
+            self.run_stage2(stage2_config, self.stage1_results)
+
+        return {
+            'stage1': self.stage1_results,
+            'stage2': self.stage2_result,
+        }
+
+    def generate_provenance(self):
+        """Generate provenance report for the two-stage pipeline.
+
+        Returns:
+            dict with stage1 and stage2 provenance info
+        """
+        report = {'stage1': {}, 'stage2': {}}
+
+        for source_name, sr in self.stage1_results.items():
+            report['stage1'][source_name] = {}
+            for type_name, dt in sr.data_types.items():
+                report['stage1'][source_name][type_name] = {
+                    'versions': sorted(dt.versions.keys()),
+                    'generic_fields': [m.name for m in dt.generic.ctype.members]
+                    if dt.generic else [],
+                }
+
+        if self.stage2_result:
+            for type_name, dt in self.stage2_result.data_types.items():
+                report['stage2'][type_name] = {
+                    'mapped_fields': [m.name for m in dt.generic.ctype.members]
+                    if dt.generic else [],
+                    'source_versions': sorted(dt.versions.keys()),
+                }
+
+        return report

--- a/tests/test_phase14.py
+++ b/tests/test_phase14.py
@@ -1,0 +1,473 @@
+"""Tests for Phase 14: Advanced emitters + two-stage pipelines (FR-26, FR-27)."""
+
+import os
+import json
+import tempfile
+import pytest
+
+from ductape.config import load_config
+from ductape.codegen import run_generate
+from ductape.emitters.emitter_base import get_emitter, list_emitters
+from ductape.conv.type_registry import TypeRegistry
+from ductape.conv.typecontainer import TypeContainer, CType, CTypeMember
+from ductape.warnings import WarningModule
+from ductape.two_stage import TwoStagePipeline, StageResult
+from ductape.struct_diff import compute_struct_diff, format_struct_diff
+from ductape.frontends.frontend_base import get_frontend
+
+
+def _ref_config_path():
+    return os.path.join(os.path.dirname(__file__), "..",
+                        "variants/reference_project/config.yaml")
+
+
+def _multi_format_dir():
+    return os.path.join(os.path.dirname(__file__), "..",
+                        "variants/reference_multi_format")
+
+
+# ── FR-26: Shared library emitter ──────────────────────────────────
+
+
+def test_shared_lib_emitter_registered():
+    """SharedLibEmitter is auto-registered."""
+    import ductape.emitters.shared_lib_emitter  # noqa: F401
+    assert "shared_lib" in list_emitters()
+
+
+def test_shared_lib_emitter_generates_files():
+    """SharedLibEmitter generates C source files."""
+    config = load_config(_ref_config_path())
+    registry = TypeRegistry(config)
+    registry.load_all()
+
+    emitter = get_emitter("shared_lib")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for type_name, dt in registry.data_types.items():
+            emitter.emit_type_header(dt, tmpdir, registry=registry)
+            emitter.emit_converter(dt, config, tmpdir)
+
+        emitter.emit_factory(registry.data_types, tmpdir)
+
+        # Check generated files
+        shared_dir = os.path.join(tmpdir, "shared_lib")
+        assert os.path.isdir(shared_dir)
+        assert os.path.isfile(os.path.join(shared_dir, "adapter_exports.h"))
+        assert os.path.isfile(os.path.join(shared_dir, "TelemetryData_t_types.h"))
+        assert os.path.isfile(os.path.join(shared_dir, "TelemetryData_t_converter.c"))
+
+
+def test_shared_lib_exports_header_content():
+    """adapter_exports.h contains correct function declarations."""
+    config = load_config(_ref_config_path())
+    registry = TypeRegistry(config)
+    registry.load_all()
+
+    emitter = get_emitter("shared_lib")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        emitter.emit_factory(registry.data_types, tmpdir)
+        with open(os.path.join(tmpdir, "shared_lib", "adapter_exports.h")) as f:
+            content = f.read()
+
+        assert "GetConverterVersion" in content
+        assert "GetSupportedVersionCount" in content
+        assert "GetSupportedVersions" in content
+        assert "ConvertData" in content
+        assert "TelemetryData_t" in content
+
+
+def test_shared_lib_converter_has_abi_exports():
+    """Converter C source has EXPORT macros and version functions."""
+    config = load_config(_ref_config_path())
+    registry = TypeRegistry(config)
+    registry.load_all()
+
+    emitter = get_emitter("shared_lib")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dt = registry.data_types["TelemetryData_t"]
+        emitter.emit_converter(dt, config, tmpdir)
+
+        with open(os.path.join(tmpdir, "shared_lib",
+                               "TelemetryData_t_converter.c")) as f:
+            content = f.read()
+
+        assert "EXPORT" in content
+        assert "TelemetryData_t_GetConverterVersion" in content
+        assert "TelemetryData_t_ConvertData" in content
+        assert "TelemetryData_t_GetSupportedVersions" in content
+        assert "switch (src_version)" in content
+
+
+def test_shared_lib_types_header_has_structs():
+    """Types header has version-specific C structs."""
+    config = load_config(_ref_config_path())
+    registry = TypeRegistry(config)
+    registry.load_all()
+
+    emitter = get_emitter("shared_lib")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dt = registry.data_types["TelemetryData_t"]
+        emitter.emit_type_header(dt, tmpdir, registry=registry)
+
+        with open(os.path.join(tmpdir, "shared_lib",
+                               "TelemetryData_t_types.h")) as f:
+            content = f.read()
+
+        assert "struct TelemetryData_t_v1" in content
+        assert "struct TelemetryData_t_v2" in content
+        assert "struct TelemetryData_t_v3" in content
+        assert "struct TelemetryData_t_generic" in content
+        assert "uint32_t timestamp" in content
+
+
+def test_shared_lib_compiles():
+    """Generated shared lib C source should compile."""
+    config = load_config(_ref_config_path())
+    registry = TypeRegistry(config)
+    registry.load_all()
+
+    emitter = get_emitter("shared_lib")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for dt in registry.data_types.values():
+            emitter.emit_type_header(dt, tmpdir, registry=registry)
+            emitter.emit_converter(dt, config, tmpdir)
+        emitter.emit_factory(registry.data_types, tmpdir)
+
+        shared_dir = os.path.join(tmpdir, "shared_lib")
+        # Compile each .c file
+        for fname in os.listdir(shared_dir):
+            if fname.endswith('.c'):
+                fpath = os.path.join(shared_dir, fname)
+                ret = os.system(
+                    f"gcc -c {fpath} -I{shared_dir} "
+                    f"-o {os.path.join(tmpdir, fname + '.o')} "
+                    f"-std=c11 -fPIC 2>/dev/null"
+                )
+                assert ret == 0, f"Failed to compile {fname}"
+
+
+# ── FR-27: Two-stage adaptation pipeline ───────────────────────────
+
+
+def test_two_stage_stage1_basic():
+    """Stage 1 builds DataTypes from parsed containers."""
+    frontend = get_frontend("protobuf")
+    config = {'_config_dir': _multi_format_dir()}
+
+    v1 = frontend.parse("schemas/sensor_v1.proto", config)
+    v2 = frontend.parse("schemas/sensor_v2.proto", config)
+
+    pipeline_config = {
+        'sources': {
+            'sensors': {
+                'stage1': {
+                    'hub_version': 'v2',
+                    'types': {
+                        'SensorReading': {
+                            'version_field': 'schema_version',
+                            'defaults': {'confidence': '0.0'},
+                            'renames': {'speed': 'ground_speed'},
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    pipeline = TwoStagePipeline(pipeline_config)
+    result = pipeline.run_stage1(
+        'sensors',
+        pipeline_config['sources']['sensors'],
+        [('v1', v1), ('v2', v2)],
+    )
+
+    assert 'SensorReading' in result.data_types
+    dt = result.data_types['SensorReading']
+    assert 1 in dt.versions
+    assert 2 in dt.versions
+    assert dt.generic is not None
+
+
+def test_two_stage_stage1_generic_has_superset():
+    """Stage 1 generic version is a superset of all fields."""
+    frontend = get_frontend("protobuf")
+    config = {'_config_dir': _multi_format_dir()}
+
+    v1 = frontend.parse("schemas/sensor_v1.proto", config)
+    v2 = frontend.parse("schemas/sensor_v2.proto", config)
+
+    pipeline_config = {
+        'sources': {
+            'sensors': {
+                'stage1': {
+                    'types': {
+                        'SensorReading': {
+                            'renames': {'speed': 'ground_speed'},
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    pipeline = TwoStagePipeline(pipeline_config)
+    result = pipeline.run_stage1(
+        'sensors',
+        pipeline_config['sources']['sensors'],
+        [('v1', v1), ('v2', v2)],
+    )
+
+    dt = result.data_types['SensorReading']
+    gen_names = [m.name for m in dt.generic.ctype.members]
+    # Should have all fields from both versions
+    assert 'timestamp' in gen_names
+    assert 'ground_speed' in gen_names  # renamed from speed
+    assert 'confidence' in gen_names     # only in v2
+    assert 'source_quality' in gen_names  # only in v2
+
+
+def test_two_stage_stage2_mapping():
+    """Stage 2 maps fields between format families."""
+    frontend = get_frontend("protobuf")
+    config = {'_config_dir': _multi_format_dir()}
+
+    v1 = frontend.parse("schemas/sensor_v1.proto", config)
+    v2 = frontend.parse("schemas/sensor_v2.proto", config)
+
+    pipeline_config = {
+        'sources': {
+            'sensors': {
+                'stage1': {
+                    'types': {
+                        'SensorReading': {
+                            'renames': {'speed': 'ground_speed'},
+                        },
+                    },
+                },
+            },
+        },
+        'stage2': {
+            'type_mappings': {
+                'SensorReading': 'PlatformTrack_t',
+            },
+            'field_mappings': {
+                'SensorReading': {
+                    'latitude': 'lat',
+                    'longitude': 'lon',
+                    'ground_speed': 'velocity',
+                    'altitude_m': 'alt_msl',
+                },
+            },
+        },
+    }
+
+    pipeline = TwoStagePipeline(pipeline_config)
+
+    # Run stage 1
+    pipeline.run_stage1(
+        'sensors',
+        pipeline_config['sources']['sensors'],
+        [('v1', v1), ('v2', v2)],
+    )
+
+    # Run stage 2
+    result = pipeline.run_stage2(
+        pipeline_config['stage2'],
+        pipeline.stage1_results,
+    )
+
+    assert 'PlatformTrack_t' in result.data_types
+    pt = result.data_types['PlatformTrack_t']
+    assert pt.generic is not None
+
+    mapped_names = [m.name for m in pt.generic.ctype.members]
+    assert 'lat' in mapped_names       # mapped from latitude
+    assert 'lon' in mapped_names       # mapped from longitude
+    assert 'velocity' in mapped_names  # mapped from ground_speed
+    assert 'alt_msl' in mapped_names   # mapped from altitude_m
+
+
+def test_two_stage_full_pipeline():
+    """Full pipeline run processes both stages."""
+    frontend = get_frontend("protobuf")
+    config = {'_config_dir': _multi_format_dir()}
+
+    v1 = frontend.parse("schemas/sensor_v1.proto", config)
+    v2 = frontend.parse("schemas/sensor_v2.proto", config)
+
+    pipeline_config = {
+        'sources': {
+            'sensors': {
+                'stage1': {
+                    'types': {
+                        'SensorReading': {
+                            'renames': {'speed': 'ground_speed'},
+                        },
+                    },
+                },
+            },
+        },
+        'stage2': {
+            'type_mappings': {'SensorReading': 'PlatformTrack_t'},
+            'field_mappings': {'SensorReading': {'latitude': 'lat'}},
+        },
+    }
+
+    pipeline = TwoStagePipeline(pipeline_config)
+    results = pipeline.run({
+        'sensors': {
+            'config': pipeline_config['sources']['sensors'],
+            'containers': [('v1', v1), ('v2', v2)],
+        },
+    })
+
+    assert 'stage1' in results
+    assert 'stage2' in results
+    assert 'sensors' in results['stage1']
+    assert 'PlatformTrack_t' in results['stage2'].data_types
+
+
+def test_two_stage_provenance():
+    """Pipeline produces provenance report."""
+    frontend = get_frontend("protobuf")
+    config = {'_config_dir': _multi_format_dir()}
+
+    v1 = frontend.parse("schemas/sensor_v1.proto", config)
+    v2 = frontend.parse("schemas/sensor_v2.proto", config)
+
+    pipeline_config = {
+        'sources': {
+            'sensors': {
+                'stage1': {
+                    'types': {
+                        'SensorReading': {'renames': {}},
+                    },
+                },
+            },
+        },
+        'stage2': {
+            'type_mappings': {'SensorReading': 'PlatformTrack_t'},
+            'field_mappings': {'SensorReading': {}},
+        },
+    }
+
+    pipeline = TwoStagePipeline(pipeline_config)
+    pipeline.run({
+        'sensors': {
+            'config': pipeline_config['sources']['sensors'],
+            'containers': [('v1', v1), ('v2', v2)],
+        },
+    })
+
+    prov = pipeline.generate_provenance()
+    assert 'stage1' in prov
+    assert 'stage2' in prov
+    assert 'sensors' in prov['stage1']
+    assert 'SensorReading' in prov['stage1']['sensors']
+    assert 'PlatformTrack_t' in prov['stage2']
+
+
+def test_two_stage_missing_source_type_warns():
+    """Stage 2 with missing source type adds a warning."""
+    wm = WarningModule(min_severity=0, use_color=False)
+    pipeline_config = {
+        'sources': {},
+        'stage2': {
+            'type_mappings': {'NonExistent': 'Target_t'},
+            'field_mappings': {},
+        },
+    }
+
+    pipeline = TwoStagePipeline(pipeline_config, warning_module=wm)
+    result = pipeline.run_stage2(
+        pipeline_config['stage2'], {},
+    )
+
+    assert wm.has_errors()
+
+
+# ── Structural diff ────────────────────────────────────────────────
+
+
+def test_struct_diff_identical_dirs():
+    """Identical directories report no differences."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_generate(_ref_config_path(), tmpdir)
+        diff = compute_struct_diff(tmpdir, tmpdir)
+        assert diff['only_in_dir1'] == []
+        assert diff['only_in_dir2'] == []
+        assert diff['differing'] == []
+        assert len(diff['identical']) > 0
+
+
+def test_struct_diff_different_dirs():
+    """Different directories report differences."""
+    with tempfile.TemporaryDirectory() as dir1:
+        with tempfile.TemporaryDirectory() as dir2:
+            run_generate(_ref_config_path(), dir1)
+            run_generate(_ref_config_path(), dir2)
+
+            # Modify a file in dir2
+            mod_file = os.path.join(dir2, "version_overview.json")
+            with open(mod_file, 'w') as f:
+                json.dump({"modified": True}, f)
+
+            diff = compute_struct_diff(dir1, dir2)
+            assert "version_overview.json" in diff['differing']
+
+
+def test_struct_diff_extra_files():
+    """Extra files in one directory are reported."""
+    with tempfile.TemporaryDirectory() as dir1:
+        with tempfile.TemporaryDirectory() as dir2:
+            run_generate(_ref_config_path(), dir1)
+            run_generate(_ref_config_path(), dir2)
+
+            # Add extra file to dir2
+            with open(os.path.join(dir2, "extra.txt"), 'w') as f:
+                f.write("extra")
+
+            diff = compute_struct_diff(dir1, dir2)
+            assert "extra.txt" in diff['only_in_dir2']
+
+
+def test_struct_diff_format():
+    """format_struct_diff produces readable output."""
+    diff = {
+        'only_in_dir1': ['old.h'],
+        'only_in_dir2': ['new.h'],
+        'differing': ['changed.cpp'],
+        'identical': ['same.h'],
+    }
+    text = format_struct_diff(diff, "/a", "/b")
+    assert "Only in dir1" in text
+    assert "old.h" in text
+    assert "Only in dir2" in text
+    assert "new.h" in text
+    assert "Differing" in text
+    assert "changed.cpp" in text
+    assert "Identical: 1 files" in text
+
+
+# ── Integration: existing pipeline still works ─────────────────────
+
+
+def test_existing_pipeline_unaffected():
+    """Existing C++ pipeline still produces correct output."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_generate(_ref_config_path(), tmpdir)
+        assert os.path.isfile(os.path.join(tmpdir, "data_types", "TelemetryData_t.h"))
+        assert os.path.isfile(os.path.join(tmpdir, "converters", "generated", "converters.cpp"))
+        assert os.path.isfile(os.path.join(tmpdir, "version_overview.json"))
+
+
+def test_all_emitters_registered():
+    """All emitters (cpp + shared_lib) are discoverable."""
+    emitters = list_emitters()
+    assert "cpp" in emitters
+    assert "shared_lib" in emitters


### PR DESCRIPTION
## Summary

Implements Phase 14 advanced emitters and two-stage pipelines (FR-26, FR-27).

- **FR-26**: Shared library emitter — C source with stable ABI, exports `GetConverterVersion()`, `ConvertData()`, `GetSupportedVersions()`. Cross-platform EXPORT macros. Compiles with `gcc -std=c11 -fPIC`.
- **FR-27**: Two-stage adaptation pipeline — Stage 1 normalizes within format family (intra-format versioning), Stage 2 normalizes across formats (cross-format field mapping). Both use hub-and-spoke engine.
- Structural diff tool (`struct_diff.py`) and `struct-diff` CLI command
- `ductape struct-diff --dir1 DIR1 --dir2 DIR2`

> **Depends on**: #15

## Test plan

- [ ] 18 new tests in `test_phase14.py`
- [ ] Shared lib: file generation, C ABI exports, struct types, gcc compilation
- [ ] Two-stage: stage1 generic, stage2 mapping, full pipeline, provenance
- [ ] Structural diff: identical/different/extra files
